### PR TITLE
Move g3 convertions from g3 to frame3sharp part 1

### DIFF
--- a/FContext.cs
+++ b/FContext.cs
@@ -913,7 +913,7 @@ namespace f3 {
                 Scene.SetSceneScale(1.0f);
                 ActiveCamera.Manipulator().ResetSceneOrbit(Scene, true, true, true);
                 // [RMS] above should already do this, but sometimes it gets confused..
-                Scene.RootGameObject.SetRotation(Quaternion.identity);
+                Scene.RootGameObject.SetRotation(Quaternionf.Identity);
                 ActiveCamera.Manipulator().ResetScenePosition(scene);
                 ActiveCamera.Manipulator().SceneTranslate(Scene, SceneGraphConfig.InitialSceneTranslate, true);
             };
@@ -986,11 +986,11 @@ namespace f3 {
 			UIRayHit sceneHit = null, cockpitHit = null;
 
             bool bCockpitOnly = (options.EnableCockpit && activeCockpit.GrabFocus);
-			if (bCockpitOnly == false && scene.FindUIRayIntersection(eyeRay, out sceneHit) ) {
+			if (bCockpitOnly == false && scene.FindUIRayIntersection(eyeRay.ToRay3f(), out sceneHit) ) {
 				bestHit = sceneHit;
 			}
 			if ( Use2DCockpit == false && options.EnableCockpit 
-                && activeCockpit.FindUIRayIntersection(eyeRay, out cockpitHit) ) {
+                && activeCockpit.FindUIRayIntersection(eyeRay.ToRay3f(), out cockpitHit) ) {
 				    if ( cockpitHit.fHitDist < bestHit.fHitDist )
 					    bestHit = cockpitHit;
 			}
@@ -1004,11 +1004,11 @@ namespace f3 {
             UIRayHit sceneHit = null, cockpitHit = null;
 
             bool bCockpitOnly = (options.EnableCockpit && activeCockpit.GrabFocus);
-            if (bCockpitOnly == false && scene.FindUIHoverRayIntersection(eyeRay, out sceneHit)) {
+            if (bCockpitOnly == false && scene.FindUIHoverRayIntersection(eyeRay.ToRay3f(), out sceneHit)) {
                 bestHit = sceneHit;
             }
             if ( Use2DCockpit == false && options.EnableCockpit 
-                && activeCockpit.FindUIHoverRayIntersection(eyeRay, out cockpitHit)) {
+                && activeCockpit.FindUIHoverRayIntersection(eyeRay.ToRay3f(), out cockpitHit)) {
                     if (cockpitHit.fHitDist < bestHit.fHitDist)
                         bestHit = cockpitHit;
             }
@@ -1026,11 +1026,11 @@ namespace f3 {
 
             bool bCockpitOnly = (options.EnableCockpit && activeCockpit.GrabFocus);
 
-            if (bCockpitOnly == false && scene.FindAnyRayIntersection (eyeRay, out sceneHit)) {
+            if (bCockpitOnly == false && scene.FindAnyRayIntersection (eyeRay.ToRay3f(), out sceneHit)) {
 				anyHit = sceneHit;
 			}
 			if (Use2DCockpit == false && options.EnableCockpit 
-                && activeCockpit.FindUIRayIntersection (eyeRay, out cockpitHit)) {
+                && activeCockpit.FindUIRayIntersection (eyeRay.ToRay3f(), out cockpitHit)) {
 				    if (cockpitHit.fHitDist < anyHit.fHitDist)
 					    anyHit = new AnyRayHit(cockpitHit);
 			}

--- a/FScene.cs
+++ b/FScene.cs
@@ -860,7 +860,7 @@ namespace f3
 			hit = null;
 			foreach (var go in this.vBoundsObjects) {
 				GameObjectRayHit myHit = null;
-				if (UnityUtil.FindGORayIntersection (ray, go, out myHit)) {
+				if (UnityUtil.FindGORayIntersection (ray.ToRay(), go, out myHit)) {
 					if (hit == null || myHit.fHitDist < hit.fHitDist)
 						hit = myHit;
 				}

--- a/GameObjectSet.cs
+++ b/GameObjectSet.cs
@@ -181,8 +181,8 @@ namespace f3
                     if (collider.Raycast(ray, out hitInfo, Mathf.Infinity)) {
                         if (hitInfo.distance < hit.fHitDist) {
                             hit.fHitDist = hitInfo.distance;
-                            hit.hitPos = hitInfo.point;
-                            hit.hitNormal = hitInfo.normal;
+                            hit.hitPos = hitInfo.point.ToVector3f();
+                            hit.hitNormal = hitInfo.normal.ToVector3f();
                             hit.hitGO = go;
                         }
                     }

--- a/SpatialInputController.cs
+++ b/SpatialInputController.cs
@@ -181,11 +181,11 @@ namespace f3 {
                     //float fRotationT = 1.0f;
 
                     if (h.SmoothedHandFrame.Origin != Vector3f.Zero) {
-                        Vector3 new_origin = 
-                            Vector3f.Lerp(h.SmoothedHandFrame.Origin, h.AbsoluteHandFrame.Origin, fPositionT).ToVector3();
-                        Quaternion new_rotation =
-                            Quaternionf.Slerp(h.SmoothedHandFrame.Rotation, h.AbsoluteHandFrame.Rotation, fRotationT).ToQuaternion();
-                        h.SmoothedHandFrame = new Frame3f(new_origin.ToVector3f(), new_rotation.ToQuaternionf());
+                        Vector3f new_origin =
+                            Vector3f.Lerp(h.SmoothedHandFrame.Origin, h.AbsoluteHandFrame.Origin, fPositionT);
+                        Quaternionf new_rotation =
+                            Quaternionf.Slerp(h.SmoothedHandFrame.Rotation, h.AbsoluteHandFrame.Rotation, fRotationT);
+                        h.SmoothedHandFrame = new Frame3f(new_origin, new_rotation);
                     } else 
                         h.SmoothedHandFrame = h.AbsoluteHandFrame;
 

--- a/SpatialInputController.cs
+++ b/SpatialInputController.cs
@@ -173,7 +173,7 @@ namespace f3 {
                     Vector3 handPos = VRPlatform.GetLocalControllerPosition(i);
                     Quaternion handRot = VRPlatform.GetLocalControllerRotation(i);
 
-                    h.AbsoluteHandFrame = new Frame3f(rootPos + handPos, handRot);
+                    h.AbsoluteHandFrame = new Frame3f((rootPos + handPos).ToVector3f(), handRot.ToQuaternionf());
 
                     float fPositionT = 0.2f;
                     float fRotationT = 0.2f;
@@ -182,22 +182,22 @@ namespace f3 {
 
                     if (h.SmoothedHandFrame.Origin != Vector3f.Zero) {
                         Vector3 new_origin = 
-                            Vector3.Lerp(h.SmoothedHandFrame.Origin, h.AbsoluteHandFrame.Origin, fPositionT);
+                            Vector3f.Lerp(h.SmoothedHandFrame.Origin, h.AbsoluteHandFrame.Origin, fPositionT).ToVector3();
                         Quaternion new_rotation =
-                            Quaternion.Slerp(h.SmoothedHandFrame.Rotation, h.AbsoluteHandFrame.Rotation, fRotationT);
-                        h.SmoothedHandFrame = new Frame3f(new_origin, new_rotation);
+                            Quaternionf.Slerp(h.SmoothedHandFrame.Rotation, h.AbsoluteHandFrame.Rotation, fRotationT).ToQuaternion();
+                        h.SmoothedHandFrame = new Frame3f(new_origin.ToVector3f(), new_rotation.ToQuaternionf());
                     } else 
                         h.SmoothedHandFrame = h.AbsoluteHandFrame;
 
-                    h.Hand.transform.position = h.SmoothedHandFrame.Origin;
-                    h.Hand.transform.rotation = h.SmoothedHandFrame.Rotation * (Quaternionf)handGeomRotation;
+                    h.Hand.transform.position = h.SmoothedHandFrame.Origin.ToVector3();
+                    h.Hand.transform.rotation = h.SmoothedHandFrame.Rotation.ToQuaternion() * handGeomRotation;
 
-                    h.CursorRay = new Ray(h.SmoothedHandFrame.Origin, 
-                        (h.SmoothedHandFrame.Rotation * Vector3.forward).Normalized );
+                    h.CursorRay = new Ray3f(h.SmoothedHandFrame.Origin, 
+                        (h.SmoothedHandFrame.Rotation * Vector3f.AxisZ).Normalized ).ToRay();
 
                     if (Mathf.Abs(h.CursorRay.direction.sqrMagnitude - 1.0f) > 0.001f) {
                         DebugUtil.Log(2, "SpatialInputController.Update - invlaid cursor ray! rotation was {0}", h.SmoothedHandFrame.Rotation);
-                        h.CursorRay = new Ray(h.SmoothedHandFrame.Origin, Vector3.up);
+                        h.CursorRay = new Ray(h.SmoothedHandFrame.Origin.ToVector3(), Vector3.up);
                     }
 
                     // raycast into scene to see if we hit object, UI, bounds, etc. 
@@ -207,8 +207,8 @@ namespace f3 {
                         // want to hit-test active gizmo first, because that has hit-priority
                         if ( context.TransformManager.HaveActiveGizmo ) {
                             UIRayHit uiHit = null;
-                            if ( context.TransformManager.ActiveGizmo.FindRayIntersection(h.CursorRay, out uiHit) ) {
-                                h.RayHitPos = uiHit.hitPos;
+                            if ( context.TransformManager.ActiveGizmo.FindRayIntersection(h.CursorRay.ToRay3f(), out uiHit) ) {
+                                h.RayHitPos = uiHit.hitPos.ToVector3();
                                 bHit = true;
                                 bHitGizmo = true;
                             }
@@ -217,15 +217,15 @@ namespace f3 {
                         if (bHit == false) {
                             AnyRayHit hit = null;
                             if (context.FindAnyRayIntersection(h.CursorRay, out hit)) {
-                                h.RayHitPos = hit.hitPos;
+                                h.RayHitPos = hit.hitPos.ToVector3();
                                 bHit = true;
                             }
                         }
                         // finally test worldbounds
                         if (bHit == false) { 
                             GameObjectRayHit ghit = null;
-                            if (context.GetScene().FindWorldBoundsHit(h.CursorRay, out ghit)) {
-                                h.RayHitPos = ghit.hitPos;
+                            if (context.GetScene().FindWorldBoundsHit(h.CursorRay.ToRay3f(), out ghit)) {
+                                h.RayHitPos = ghit.hitPos.ToVector3();
                             }
                         }
                     }
@@ -233,8 +233,8 @@ namespace f3 {
                     // if not, plane cursor on view-perp plane centered at last hit pos,
                     // otherwise it will be stuck/disappear
                     if ( bHit == false ) {
-                        Frame3f f = new Frame3f(h.RayHitPos, camera.transform.forward);
-                        h.RayHitPos = f.RayPlaneIntersection(h.CursorRay.origin, h.CursorRay.direction, 2);
+                        Frame3f f = new Frame3f(h.RayHitPos.ToVector3f(), camera.transform.forward.ToVector3f());
+                        h.RayHitPos = f.RayPlaneIntersection(h.CursorRay.origin.ToVector3f(), h.CursorRay.direction.ToVector3f(), 2).ToVector3();
                     }
 
                     h.Cursor.transform.position = h.RayHitPos;
@@ -249,7 +249,7 @@ namespace f3 {
                         MaterialUtil.SetMaterial(h.Cursor, h.CursorDefaultMaterial);
 
                     // maintain a consistent visual size for 3D cursor sphere
-                    float fScaling = VRUtil.GetVRRadiusForVisualAngle(h.RayHitPos, camera.transform.position, CursorVisualAngleInDegrees);
+                    float fScaling = VRUtil.GetVRRadiusForVisualAngle(h.RayHitPos.ToVector3f(), camera.transform.position.ToVector3f(), CursorVisualAngleInDegrees);
                     h.Cursor.transform.localScale = fScaling * Vector3.one;
 
                     // orient cursor so it is tilted like a 2D cursor, but per-hand
@@ -264,7 +264,7 @@ namespace f3 {
                         float hDist = (h.RayHitPos - h.CursorRay.origin).magnitude;
                         Vector3 p0 = h.RayHitPos - 0.9f * hDist * h.CursorRay.direction;
                         Vector3 p1 = h.RayHitPos + 100.0f*h.CursorRay.direction;
-                        float r0 = VRUtil.GetVRRadiusForVisualAngle(p0, camera.transform.position, 0.5f);
+                        float r0 = VRUtil.GetVRRadiusForVisualAngle(p0.ToVector3f(), camera.transform.position.ToVector3f(), 0.5f);
                         h.LaserRen.SetPosition(0, p0);
                         h.LaserRen.SetPosition(1, p1);
                         h.LaserRen.startWidth = h.LaserRen.endWidth = r0;
@@ -304,7 +304,7 @@ namespace f3 {
             }
 
             h.HandIcon = 
-                UnityUtil.CreateMeshGO("hand_icon", m, MaterialUtil.CreateStandardVertexColorMaterial(Color.white), false);
+                UnityUtil.CreateMeshGO("hand_icon", m, MaterialUtil.CreateStandardVertexColorMaterial(Colorf.White), false);
             float s = SceneGraphConfig.VRHandArrowRadius;
             h.HandIcon.transform.localScale = s * 0.3f * Vector3.one;
             h.HandIcon.transform.localPosition = new Vector3(0.0f, -0.3f*s, -0.3f*s);

--- a/SystemMouseCursorController.cs
+++ b/SystemMouseCursorController.cs
@@ -41,8 +41,8 @@ namespace f3 {
 		public void Update ()
         {
             // just convert current system mouse position into ray
-            CurrentWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(Input.mousePosition);
-            CurrentUIRay = ((Camera)context.OrthoUICamera).ScreenPointToRay(Input.mousePosition);
+            CurrentWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(Input.mousePosition).ToRay3f();
+            CurrentUIRay = ((Camera)context.OrthoUICamera).ScreenPointToRay(Input.mousePosition).ToRay3f();
         }
 
 

--- a/TouchMouseCursorController.cs
+++ b/TouchMouseCursorController.cs
@@ -49,16 +49,16 @@ namespace f3 {
         {
             // just convert current touch position into ray
             if (Input.touchCount > 0) {
-                Vector2f touchPos = Input.touches[0].position;
+                Vector2f touchPos = Input.touches[0].position.ToVector2f();
                 Vector3f touchPos3 = new Vector3f(touchPos.x, touchPos.y, 0);
-                CurrentWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(touchPos3);
-                CurrentUIRay = ((Camera)context.OrthoUICamera).ScreenPointToRay(touchPos3);
+                CurrentWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(touchPos3.ToVector3()).ToRay3f();
+                CurrentUIRay = ((Camera)context.OrthoUICamera).ScreenPointToRay(touchPos3.ToVector3()).ToRay3f();
             }
             if (Input.touchCount > 1) {
-                Vector2f touchPos = Input.touches[1].position;
+                Vector2f touchPos = Input.touches[1].position.ToVector2f();
                 Vector3f touchPos3 = new Vector3f(touchPos.x, touchPos.y, 0);
                 secondWorldRayValid = true;
-                secondWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(touchPos3);
+                secondWorldRay = ((Camera)context.ActiveCamera).ScreenPointToRay(touchPos3.ToVector3()).ToRay3f();
             } else {
                 secondWorldRayValid = false;
             }

--- a/UIElements/HUDButton.cs
+++ b/UIElements/HUDButton.cs
@@ -189,7 +189,7 @@ namespace f3
                 return true;
             }
 
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDLabel.cs
+++ b/UIElements/HUDLabel.cs
@@ -205,7 +205,7 @@ namespace f3
                 return true;
             }
 
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDMultiLineLabel.cs
+++ b/UIElements/HUDMultiLineLabel.cs
@@ -194,7 +194,7 @@ namespace f3
                 return true;
             }
 
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDPopupMessage.cs
+++ b/UIElements/HUDPopupMessage.cs
@@ -200,7 +200,7 @@ namespace f3
 
         override public bool EndCapture(InputEvent e)
         {
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
                 if (EnableClickToDismiss) {
                     Dismiss();
                 } else {

--- a/UIElements/HUDRadialMenu.cs
+++ b/UIElements/HUDRadialMenu.cs
@@ -68,8 +68,8 @@ namespace f3
             WedgePadding = 5.0f;
             Radius = 0.5f;
             DeadZoneRadiusFactor = 0.2f;
-            ItemColor = ColorUtil.replaceAlpha(ColorUtil.ForestGreen, 0.8f);
-            HighlightColor = ColorUtil.replaceAlpha(ColorUtil.SelectionGold, 0.9f);
+            ItemColor = ColorUtil.replaceAlpha(ColorUtil.ForestGreen, 0.8f).ToColor();
+            HighlightColor = ColorUtil.replaceAlpha(ColorUtil.SelectionGold, 0.9f).ToColor();
             TextScale = 0.01f;
             TextCenterPointFactor = 0.6f;
 
@@ -113,8 +113,8 @@ namespace f3
         {
             menuContainer = new GameObject(UniqueNames.GetNext("HUDRadialMenu"));
 
-            itemMaterial = MaterialUtil.CreateFlatMaterial(ItemColor);
-            highlightMaterial = MaterialUtil.CreateFlatMaterial(HighlightColor);
+            itemMaterial = MaterialUtil.CreateFlatMaterial(ItemColor.ToColorf());
+            highlightMaterial = MaterialUtil.CreateFlatMaterial(HighlightColor.ToColorf());
 
 
             float fInnerRadius = Radius * DeadZoneRadiusFactor;
@@ -278,7 +278,7 @@ namespace f3
 
         override public bool UpdateCapture(InputEvent e)
         {
-            GameObject hitGO = FindHitGO(e.ray);
+            GameObject hitGO = FindHitGO(e.ray.ToRay());
 
             // find item we want to higlight
             MenuItem highlightItem =  (hitGO == null) ? null : AllItems.Find((x) => x.GO == hitGO);
@@ -315,11 +315,11 @@ namespace f3
 
         override public bool EndCapture(InputEvent e)
         {
-            GameObject hitGO = FindHitGO(e.ray);
+            GameObject hitGO = FindHitGO(e.ray.ToRay());
             if ( hitGO != null) {
 
                 GameObjectRayHit hit;
-                if (FindGORayIntersection(e.ray, out hit)) {
+                if (FindGORayIntersection(e.ray.ToRay(), out hit)) {
                     float fDist = (hit.hitPos - RootGameObject.GetPosition()).Length;
                     if (fDist < Radius * DeadZoneRadiusFactor)
                         return true;

--- a/UIElements/HUDSecureTextEntry.cs
+++ b/UIElements/HUDSecureTextEntry.cs
@@ -312,7 +312,7 @@ namespace f3
 
         override public bool EndCapture(InputEvent e)
         {
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDShapeElement.cs
+++ b/UIElements/HUDShapeElement.cs
@@ -136,7 +136,7 @@ namespace f3
                 return true;
             }
 
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDSliderBase.cs
+++ b/UIElements/HUDSliderBase.cs
@@ -536,7 +536,7 @@ namespace f3
             eInterMode = InteractionMode.None;
 
             GameObjectRayHit hit;
-            if (! FindGORayIntersection(e.ray, out hit) )
+            if (! FindGORayIntersection(e.ray.ToRay(), out hit) )
                 return false;       // this should not be possible...
             if ( custom_begin_capture(e, hit) ) {
                 eInterMode = InteractionMode.InCustom;

--- a/UIElements/HUDStandardItem.cs
+++ b/UIElements/HUDStandardItem.cs
@@ -126,7 +126,7 @@ namespace f3
                 return false;
 
 			GameObjectRayHit hitg = null;
-			if (FindGORayIntersection (ray, out hitg)) {
+			if (FindGORayIntersection (ray.ToRay(), out hitg)) {
 				if (hitg.hitGO != null) {
 					hit = new UIRayHit (hitg, this);
 					return true;
@@ -145,7 +145,7 @@ namespace f3
                 return false;
 
             GameObjectRayHit hitg = null;
-            if (FindGORayIntersection(ray, out hitg)) {
+            if (FindGORayIntersection(ray.ToRay(), out hitg)) {
                 if (hitg.hitGO != null) {
                     hit = new UIRayHit(hitg, this);
                     return true;

--- a/UIElements/HUDTextEntry.cs
+++ b/UIElements/HUDTextEntry.cs
@@ -265,7 +265,7 @@ namespace f3
 
         override public bool EndCapture(InputEvent e)
         {
-            if (FindHitGO(e.ray)) {
+            if (FindHitGO(e.ray.ToRay())) {
 
                 if (sent_click == false) {
                     // on first click we reset timer

--- a/UIElements/HUDToggleButton.cs
+++ b/UIElements/HUDToggleButton.cs
@@ -127,7 +127,7 @@ namespace f3
                 return true;
             }
 
-            if (IsGOHit (e.ray, buttonMesh)) {
+            if (IsGOHit (e.ray.ToRay(), buttonMesh)) {
                 // this is a bit hacky...if we are in a group, then we only toggle disabled -> enabled on click,
                 // not enabled->disabled
                 if ( parentGroup != null) {

--- a/VRMouseCursorController.cs
+++ b/VRMouseCursorController.cs
@@ -23,8 +23,8 @@ namespace f3 {
 
         public Ray3f CurrentCursorWorldRay()
         {
-			Vector3f camPos = CurrentCursorRaySourceWorld;
-			Vector3f cursorPos = CurrentCursorPosWorld;
+			Vector3f camPos = CurrentCursorRaySourceWorld.ToVector3f();
+			Vector3f cursorPos = CurrentCursorPosWorld.ToVector3f();
 			Ray3f ray = new Ray3f(camPos, (cursorPos - camPos).Normalized);
             if (Math.Abs(ray.Direction.LengthSquared - 1) > 0.001f)
                 ray = new Ray3f(camPos, Vector3f.AxisY);
@@ -83,10 +83,10 @@ namespace f3 {
 			vPlaneCursorPos = Vector3.zero;
 			vSceneCursorPos = vPlaneCursorPos;
 
-            CursorDefaultMaterial = MaterialUtil.CreateTransparentMaterial (Color.grey, 0.6f);
+            CursorDefaultMaterial = MaterialUtil.CreateTransparentMaterial (Colorf.Grey, 0.6f);
 			//CursorHitMaterial = MaterialUtil.CreateTransparentMaterial (Color.yellow, 0.8f);
-            CursorHitMaterial = MaterialUtil.CreateStandardMaterial(Color.yellow);
-            CursorCapturingMaterial = MaterialUtil.CreateTransparentMaterial (Color.yellow, 0.75f);
+            CursorHitMaterial = MaterialUtil.CreateStandardMaterial(Colorf.Yellow);
+            CursorCapturingMaterial = MaterialUtil.CreateTransparentMaterial (Colorf.Yellow, 0.75f);
 
 			CursorVisualAngleInDegrees = 1.5f;
 
@@ -105,7 +105,7 @@ namespace f3 {
 			xformObject.SetName("cursor_plane");
             MaterialUtil.DisableShadows(xformObject);
             xformObject.GetComponent<MeshRenderer>().material 
-                = MaterialUtil.CreateTransparentMaterial (Color.cyan, 0.2f);
+                = MaterialUtil.CreateTransparentMaterial (Colorf.Cyan, 0.2f);
             xformObject.GetComponent<MeshRenderer>().enabled = false;
 
             lastMouseEventTime = FPlatform.RealTime();
@@ -146,9 +146,9 @@ namespace f3 {
                 //  local plane coords). So raycast through old cursor to hit new plane and figure
                 //  out new local coords (fCurPlaneX, fCurPlaneY)
                 if (bWasInCaptureFreeze) {
-                    Frame3f newF = new Frame3f(vCursorPlaneOrigin, this.camera.transform.forward);
-                    Vector3 vPlaneHit = newF.RayPlaneIntersection(this.vRaySourcePosition,
-                        (vPlaneCursorPos - vRaySourcePosition).normalized, 2);
+                    Frame3f newF = new Frame3f(vCursorPlaneOrigin.ToVector3f(), this.camera.transform.forward.ToVector3f());
+                    Vector3 vPlaneHit = newF.RayPlaneIntersection(this.vRaySourcePosition.ToVector3f(),
+                        (vPlaneCursorPos - vRaySourcePosition).normalized.ToVector3f(), 2).ToVector3();
                     fCurPlaneX = Vector3.Dot((vPlaneHit - vCursorPlaneOrigin), vCursorPlaneRight);
                     fCurPlaneY = Vector3.Dot((vPlaneHit - vCursorPlaneOrigin), vCursorPlaneUp);
                     bWasInCaptureFreeze = false;
@@ -207,12 +207,12 @@ namespace f3 {
 				Ray r = new Ray (camera.transform.position, (vPlaneCursorPos - camera.transform.position).normalized);
 				AnyRayHit hit = null;
                 if (context.FindAnyRayIntersection(r, out hit)) {
-                    vSceneCursorPos = hit.hitPos;
+                    vSceneCursorPos = hit.hitPos.ToVector3();
                     bHit = true;
                 } else {
                     GameObjectRayHit ghit = null;
-                    if (context.GetScene().FindWorldBoundsHit(r, out ghit)) {
-                        vSceneCursorPos = ghit.hitPos;
+                    if (context.GetScene().FindWorldBoundsHit(r.ToRay3f(), out ghit)) {
+                        vSceneCursorPos = ghit.hitPos.ToVector3();
                         //bIsBoundsHit = true;
                     }
                 }
@@ -242,7 +242,7 @@ namespace f3 {
             Cursor.SetLayer(FPlatform.CursorLayer);
 
             // maintain a consistent visual size for 3D cursor sphere
-            float fScaling = VRUtil.GetVRRadiusForVisualAngle(vSceneCursorPos, camera.transform.position, CursorVisualAngleInDegrees);
+            float fScaling = VRUtil.GetVRRadiusForVisualAngle(vSceneCursorPos.ToVector3f(), camera.transform.position.ToVector3f(), CursorVisualAngleInDegrees);
 			Cursor.transform.localScale = new Vector3 (fScaling, fScaling, fScaling);
 
             // update cursor

--- a/animation/CameraAnimator.cs
+++ b/animation/CameraAnimator.cs
@@ -28,7 +28,7 @@ namespace f3
         {
             fadeObject = new fGameObject( GameObject.CreatePrimitive(PrimitiveType.Sphere), FGOFlags.NoFlags );
             //fadeObject.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
-            fadeObject.SetMaterial(MaterialUtil.CreateFlatMaterial(Color.black, 0.0f), true);
+            fadeObject.SetMaterial(MaterialUtil.CreateFlatMaterial(Color.black.ToColorf(), 0.0f), true);
             fadeObject.SetName("fade_sphere");
             UnityUtil.ReverseMeshOrientation(fadeObject.GetMesh());
             fadeObject.SetParent(UseCamera.GameObject(), false);
@@ -44,14 +44,14 @@ namespace f3
             // figure out the pan that we would apply to camera, then apply the delta to the scene
             Vector3f curPos = UseCamera.GetPosition();
             Vector3f curDir = UseCamera.GetWorldFrame().Z;
-            float fDist = Vector3.Dot((focusPointW - curPos), curDir);
+            float fDist = Vector3.Dot((focusPointW - curPos).ToVector3(), curDir.ToVector3());
             Vector3f newPos = focusPointW - fDist * curDir;
             Vector3f delta = curPos - newPos;
 
             StartCoroutine(
-                SmoothTranslate(UseScene.RootGameObject.GetPosition() + delta, duration));
+                SmoothTranslate((UseScene.RootGameObject.GetPosition() + delta).ToVector3(), duration));
             StartCoroutine(
-                SmoothMoveTarget(focusPointW + delta, duration / 10.0f));
+                SmoothMoveTarget((focusPointW + delta).ToVector3(), duration / 10.0f));
         }
 
 
@@ -201,9 +201,9 @@ namespace f3
             StartCoroutine(
                 SmoothDipToBlack(0.75f));
             StartCoroutine(
-                SmoothTranslate(UseScene.RootGameObject.GetPosition() + delta, 0.75f));
+                SmoothTranslate((UseScene.RootGameObject.GetPosition() + delta).ToVector3(), 0.75f));
             StartCoroutine(
-                SmoothMoveTarget(vNewTargetLocation+delta, 0.1f));
+                SmoothMoveTarget((vNewTargetLocation+delta).ToVector3(), 0.1f));
         }
 
 
@@ -311,7 +311,7 @@ namespace f3
 
             Action<float> tweenF = (t) => {
                 // update rotation
-                Quaternionf rot = Quaternion.Slerp(startF.Rotation, toOrientation, t);
+                Quaternionf rot = Quaternionf.Slerp(startF.Rotation, toOrientation, t);
                 UseScene.SceneFrame = new Frame3f(startF.Origin, rot);
 
                 // stay on target
@@ -344,7 +344,7 @@ namespace f3
                 Vector3f newTargetS = Vector3f.Lerp(startTargetS, toTargetS, t);
                 UseCamera.Manipulator().PanFocusOnScenePoint(UseScene, UseCamera, newTargetS);
 
-                Quaternionf rot = Quaternion.Slerp(startF.Rotation, toOrientation, t);
+                Quaternionf rot = Quaternionf.Slerp(startF.Rotation, toOrientation, t);
                 UseScene.RootGameObject.SetLocalRotation(rot);
 
                 float curDist = UseCamera.GetPosition().Distance(UseCamera.GetTarget());
@@ -381,7 +381,7 @@ namespace f3
                 Vector3f newTargetS = Vector3f.Lerp(startTargetS, toTargetS, t);
                 UseCamera.Manipulator().PanFocusOnScenePoint(UseScene, UseCamera, newTargetS);
 
-                Quaternionf rot = Quaternion.Slerp(startF.Rotation, toOrientation, t);
+                Quaternionf rot = Quaternionf.Slerp(startF.Rotation, toOrientation, t);
                 UseScene.RootGameObject.SetLocalRotation(rot);
 
                 float curHeight = UseCamera.OrthoHeight;

--- a/behaviors/InputState.cs
+++ b/behaviors/InputState.cs
@@ -294,16 +294,16 @@ namespace f3
             bRightMenuButtonDown = VRPlatform.RightMenuButtonDown;
             bRightMenuButtonReleased = VRPlatform.RightMenuButtonReleased;
 
-            vLeftStickDelta2D = VRPlatform.LeftStickPosition;
-            vRightStickDelta2D = VRPlatform.RightStickPosition;
+            vLeftStickDelta2D = VRPlatform.LeftStickPosition.ToVector2f();
+            vRightStickDelta2D = VRPlatform.RightStickPosition.ToVector2f();
 
             // [RMS] bit of a hack here, if controller is not active then ray is 0/0, and
             //   that causes lots of exceptions elsewhere! So we return a default ray pointing
             //   straight up, but hopefully clients are checking active flag and will ignore it...
             vLeftSpatialWorldRay = (bLeftControllerActive) ?
-                s.SpatialController.Left.CursorRay : new Ray(Vector3f.Zero, Vector3f.AxisY);
+                s.SpatialController.Left.CursorRay.ToRay3f() : new Ray3f(Vector3f.Zero, Vector3f.AxisY);
             vRightSpatialWorldRay = (bRightControllerActive) ?
-                s.SpatialController.Right.CursorRay : new Ray(Vector3f.Zero, Vector3f.AxisY);
+                s.SpatialController.Right.CursorRay.ToRay3f() : new Ray3f(Vector3f.Zero, Vector3f.AxisY);
 
             LeftHandFrame = s.SpatialController.Left.SmoothedHandFrame;
             RightHandFrame = s.SpatialController.Right.SmoothedHandFrame;
@@ -353,8 +353,8 @@ namespace f3
                 bDown = true;
             }
 
-            pos = t.position;
-            delta = t.deltaPosition;
+            pos = t.position.ToVector2f();
+            delta = t.deltaPosition.ToVector2f();
         }
 
 

--- a/behaviors/TouchUIBehavior.cs
+++ b/behaviors/TouchUIBehavior.cs
@@ -26,7 +26,7 @@ namespace f3
         {
             UIRayHit uiHit;
             if (input.bTouchPressed && input.nTouchCount == 1) {
-                if (scene.FindUIHit(input.vTouchWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vTouchWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.WantsCapture(InputEvent.Touch(input, new AnyRayHit(uiHit)));
                     if (bCanCapture)
                         return CaptureRequest.Begin(this);
@@ -42,7 +42,7 @@ namespace f3
 
             UIRayHit uiHit;
             if (input.bTouchPressed) {
-                if (scene.FindUIHit(input.vTouchWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vTouchWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.BeginCapture(InputEvent.Touch(input, new AnyRayHit(uiHit)));
                     if (bCanCapture) {
                         pCapturing = uiHit.hitUI;

--- a/behaviors/TwoHandViewManipBehavior.cs
+++ b/behaviors/TwoHandViewManipBehavior.cs
@@ -147,12 +147,12 @@ namespace f3
             bool bHit1 = cockpit.Scene.FindSceneRayIntersection(input.vLeftSpatialWorldRay, out hit1);
             bool bHit2 = cockpit.Scene.FindSceneRayIntersection(input.vRightSpatialWorldRay, out hit2);
             if ( bHit1 && bHit2 ) {
-                Vector3 avg = ((hit1.hitPos + hit2.hitPos) * 0.5f).ToVector3();
-                float d = VRUtil.GetVRRadiusForVisualAngle(avg.ToVector3f(), camFrame.Origin, 2.0f);
+                Vector3f avg = ((hit1.hitPos + hit2.hitPos) * 0.5f);
+                float d = VRUtil.GetVRRadiusForVisualAngle(avg, camFrame.Origin, 2.0f);
                 if ( (hit1.hitPos - hit2.hitPos).Length < d ) {
                     hi.eMode = ActionMode.SetWorldScale;
                     Frame3f centerF = cockpit.Scene.SceneFrame;
-                    centerF.Origin = avg.ToVector3f();
+                    centerF.Origin = avg;
                     Frame3f planeF = new Frame3f(centerF.Origin, camFrame.Z);
                     hi.BeginSetWorldScale(centerF, planeF, 2*d);
                     hi.UpdateSetWorldScale(input.vLeftSpatialWorldRay, input.vRightSpatialWorldRay);
@@ -215,9 +215,9 @@ namespace f3
             // zoom is indicated by moving hands together/apart. But we want to get rid of
             // influence from other gestures (like rotate below) so we project to camera-right axis first.
             Frame3f camFrame = cockpit.ActiveCamera.GetWorldFrame();
-            Vector3 right = camFrame.X.ToVector3();
+            Vector3f right = camFrame.X;
             float fOrig = Vector3f.Dot((hi.rightStartF.Origin - hi.leftStartF.Origin), hi.camRight);
-            float fCur = Vector3f.Dot((input.RightHandFrame.Origin - input.LeftHandFrame.Origin), right.ToVector3f());
+            float fCur = Vector3f.Dot((input.RightHandFrame.Origin - input.LeftHandFrame.Origin), right);
             float deltaZAbs = fCur - fOrig;
             float deltaZ = (hi.bInZoomDeadzone) ? ApplyDeadzone(deltaZAbs, fZoomDeadzoneInM) : deltaZAbs-hi.fZoomShift;
             if (Math.Abs(deltaZ) > 0 && hi.bInZoomDeadzone) {

--- a/behaviors/VRGamepadUIBehavior.cs
+++ b/behaviors/VRGamepadUIBehavior.cs
@@ -35,7 +35,7 @@ namespace f3
             UIRayHit uiHit;
             if (input.bLeftTriggerPressed || input.bAButtonPressed) {
                 ActiveInput = (input.bLeftTriggerPressed) ? WhichInput.LeftTrigger : WhichInput.AButton;
-                if (scene.FindUIHit(input.vGamepadWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vGamepadWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.WantsCapture( InputEvent.Gamepad(input, new AnyRayHit(uiHit)) );
                     if (bCanCapture)
                         return CaptureRequest.Begin(this);
@@ -51,7 +51,7 @@ namespace f3
             UIRayHit uiHit;
             if (input.bLeftTriggerPressed || input.bAButtonPressed) {
                 ActiveInput = (input.bLeftTriggerPressed) ? WhichInput.LeftTrigger : WhichInput.AButton;
-                if (scene.FindUIHit(input.vGamepadWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vGamepadWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.BeginCapture( InputEvent.Gamepad(input, new AnyRayHit(uiHit)) );
                     if (bCanCapture) {
                         pCapturing = uiHit.hitUI;
@@ -102,7 +102,7 @@ namespace f3
         public override void UpdateHover(InputState input)
         {
             UIRayHit uiHit;
-            if (scene.FindUIHoverHit(input.vGamepadWorldRay, out uiHit)) {
+            if (scene.FindUIHoverHit(input.vGamepadWorldRay.ToRay(), out uiHit)) {
                 if (activeHover != null && activeHover != uiHit.hitUI)
                     EndHover(input);
 

--- a/behaviors/VRMouseUIBehavior.cs
+++ b/behaviors/VRMouseUIBehavior.cs
@@ -26,7 +26,7 @@ namespace f3
         {
             UIRayHit uiHit;
             if (input.bLeftMousePressed) {
-                if (scene.FindUIHit(input.vMouseWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vMouseWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.WantsCapture(InputEvent.Mouse(input, new AnyRayHit(uiHit)));
                     if (bCanCapture)
                         return CaptureRequest.Begin(this);
@@ -43,7 +43,7 @@ namespace f3
 
             UIRayHit uiHit;
             if (input.bLeftMousePressed) {
-                if (scene.FindUIHit(input.vMouseWorldRay, out uiHit)) {
+                if (scene.FindUIHit(input.vMouseWorldRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.BeginCapture(InputEvent.Mouse(input, new AnyRayHit(uiHit)));
                     if (bCanCapture) {
                         pCapturing = uiHit.hitUI;
@@ -95,7 +95,7 @@ namespace f3
         public override void UpdateHover(InputState input)
         {
             UIRayHit uiHit;
-            if (scene.FindUIHoverHit(input.vMouseWorldRay, out uiHit)) {
+            if (scene.FindUIHoverHit(input.vMouseWorldRay.ToRay(), out uiHit)) {
                 if (activeHover != null && activeHover != uiHit.hitUI)
                     EndHover(input);
 

--- a/behaviors/VRSpatialDeviceUIBehavior.cs
+++ b/behaviors/VRSpatialDeviceUIBehavior.cs
@@ -25,7 +25,7 @@ namespace f3
                 CaptureSide eSide = (input.bLeftTriggerPressed) ? CaptureSide.Left : CaptureSide.Right;
                 Ray3f useRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
                 UIRayHit uiHit;
-                if (scene.FindUIHit(useRay, out uiHit)) {
+                if (scene.FindUIHit(useRay.ToRay(), out uiHit)) {
                     bool bCanCapture = uiHit.hitUI.WantsCapture(InputEvent.Spatial(eSide, input, new AnyRayHit(uiHit)));
                     if (bCanCapture)
                         return CaptureRequest.Begin(this, eSide);
@@ -39,7 +39,7 @@ namespace f3
         {
             Ray3f useRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
             UIRayHit uiHit;
-            if (scene.FindUIHit(useRay, out uiHit)) {
+            if (scene.FindUIHit(useRay.ToRay(), out uiHit)) {
                 bool bCanCapture = uiHit.hitUI.BeginCapture(InputEvent.Spatial(eSide, input, new AnyRayHit(uiHit)));
                 if (bCanCapture) {
                     return Capture.Begin(this, eSide, uiHit.hitUI );
@@ -109,7 +109,7 @@ namespace f3
         public override void UpdateHover(InputState input)
         {
             UIRayHit uiHitL;
-            if ( input.bLeftControllerActive && scene.FindUIHoverHit(input.vLeftSpatialWorldRay, out uiHitL)) {
+            if ( input.bLeftControllerActive && scene.FindUIHoverHit(input.vLeftSpatialWorldRay.ToRay(), out uiHitL)) {
                 if (activeLeftHover != null && activeLeftHover != uiHitL.hitUI)
                     deactivate_hover(input, true);
 
@@ -120,7 +120,7 @@ namespace f3
                 deactivate_hover(input, true);
 
             UIRayHit uiHitR;
-            if (input.bRightControllerActive && scene.FindUIHoverHit(input.vRightSpatialWorldRay, out uiHitR)) {
+            if (input.bRightControllerActive && scene.FindUIHoverHit(input.vRightSpatialWorldRay.ToRay(), out uiHitR)) {
                 if (activeRightHover != null && activeRightHover != uiHitR.hitUI)
                     deactivate_hover(input, false);
 

--- a/indicators/SOIndicatorSet.cs
+++ b/indicators/SOIndicatorSet.cs
@@ -73,14 +73,14 @@ namespace f3
         {
             float fSceneScale = parentSO.GetScene().GetSceneScale();
             foreach (var i in vObjects) {
-                Vector3f vPos = i.go.transform.position;
+                Vector3f vPos = i.go.transform.position.ToVector3f();
                 float fR = VRUtil.GetVRRadiusForVisualAngle(vPos, cameraPosW, i.fVisualRadiusDeg);
 
                 // have to compensate for scaling of parent SO
                 float fParentSOScale = parentSO.GetLocalScale()[0];
                 fR = fR / fParentSOScale / fSceneScale;
 
-                i.go.transform.localScale = fR * Vector3f.One;
+                i.go.transform.localScale = fR * Vector3.one;
             }
         }
 
@@ -101,9 +101,9 @@ namespace f3
             // assumption is that frames passed in are already in scaled coordinates, 
             // so we need to undo that scale
             if (bIsScaled)
-                go.transform.position = localFrame.Origin / vScale;
+                go.transform.position = (localFrame.Origin / vScale).ToVector3();
             else
-                go.transform.position = localFrame.Origin;
+                go.transform.position = localFrame.Origin.ToVector3();
             go.layer = FPlatform.WidgetOverlayLayer;
 
             UnityUtil.AddChild(parentGO, go, false);

--- a/platform/fCamera.cs
+++ b/platform/fCamera.cs
@@ -67,67 +67,67 @@ namespace f3
 
         public void SetPosition(Vector3f vPosition)
         {
-            camera.transform.position = vPosition;
+            camera.transform.position = vPosition.ToVector3();
         }
         public Vector3f GetPosition()
         {
-            return camera.transform.position;
+            return camera.transform.position.ToVector3f();
         }
 
         public virtual void SetRotation(Quaternionf rotation)
         {
-            camera.transform.rotation = rotation;
+            camera.transform.rotation = rotation.ToQuaternion();
         }
         public virtual Quaternionf GetRotation()
         {
-            return camera.transform.rotation;
+            return camera.transform.rotation.ToQuaternionf();
         }
 
         public void SetLocalPosition(Vector3f vPosition)
         {
-            camera.transform.localPosition = vPosition;
+            camera.transform.localPosition = vPosition.ToVector3();
         }
         public Vector3f GetLocalPosition()
         {
-            return camera.transform.localPosition;
+            return camera.transform.localPosition.ToVector3f();
         }
 
         public void SetLocalScale(Vector3f vScale)
         {
-            camera.transform.localScale = vScale;
+            camera.transform.localScale = vScale.ToVector3();
         }
         public void SetLocalScale(float fScale)
         {
-            camera.transform.localScale = fScale * Vector3f.One; 
+            camera.transform.localScale = fScale * Vector3.one;
         }
         public Vector3f GetLocalScale()
         {
-            return camera.transform.localScale;
+            return camera.transform.localScale.ToVector3f();
         }
 
 
         public Frame3f GetWorldFrame()
         {
-            return new Frame3f(camera.transform.position, camera.transform.rotation);
+            return new Frame3f(camera.transform.position.ToVector3f(), camera.transform.rotation.ToQuaternionf());
         }
         public void SetWorldFrame(Frame3f f)
         {
-            camera.transform.position = f.Origin;
-            camera.transform.rotation = f.Rotation;
+            camera.transform.position = f.Origin.ToVector3();
+            camera.transform.rotation = f.Rotation.ToQuaternion();
         }
 
 
         public Vector3f Forward()
         {
-            return camera.transform.forward;
+            return camera.transform.forward.ToVector3f();
         }
         public Vector3f Up()
         {
-            return camera.transform.up;
+            return camera.transform.up.ToVector3f();
         }
         public Vector3f Right()
         {
-            return camera.transform.right;
+            return camera.transform.right.ToVector3f();
         }
 
 

--- a/platform/fCurveGameObject.cs
+++ b/platform/fCurveGameObject.cs
@@ -142,7 +142,7 @@ namespace f3
             if (start != s) {
                 start = s;
                 LineRenderer r = GetComponent<LineRenderer>();
-                r.SetPosition(0, start);
+                r.SetPosition(0, start.ToVector3());
             }
         }
         public Vector3f GetStart() { return start; }
@@ -153,7 +153,7 @@ namespace f3
             if (end != e) {
                 end = e;
                 LineRenderer r = GetComponent<LineRenderer>();
-                r.SetPosition(1, end);
+                r.SetPosition(1, end.ToVector3());
             }
         }
         public Vector3f GetEnd() { return end; }

--- a/platform/fGameObject.cs
+++ b/platform/fGameObject.cs
@@ -195,7 +195,7 @@ namespace f3
         {
             if (go != null) {
                 Renderer r = go.GetComponent<Renderer>();
-                r.material.color = color;
+                r.material.color = color.ToColor();
             }
         }
 
@@ -240,53 +240,53 @@ namespace f3
 
         public virtual void SetPosition(Vector3f vPosition)
         {
-            go.transform.position = vPosition;
+            go.transform.position = vPosition.ToVector3();
         }
         public virtual Vector3f GetPosition()
         {
-            return go.transform.position;
+            return go.transform.position.ToVector3f();
         }
 
         public virtual void SetRotation(Quaternionf rotation)
         {
-            go.transform.rotation = rotation;
+            go.transform.rotation = rotation.ToQuaternion();
         }
         public virtual Quaternionf GetRotation()
         {
-            return go.transform.rotation;
+            return go.transform.rotation.ToQuaternionf();
         }
 
 
         public virtual void SetLocalPosition(Vector3f vPosition)
         {
-            go.transform.localPosition = vPosition;
+            go.transform.localPosition = vPosition.ToVector3();
         }
         public virtual Vector3f GetLocalPosition()
         {
-            return go.transform.localPosition;
+            return go.transform.localPosition.ToVector3f();
         }
 
         public virtual void SetLocalRotation(Quaternionf rotation)
         {
-            go.transform.localRotation = rotation;
+            go.transform.localRotation = rotation.ToQuaternion();
         }
         public virtual Quaternionf GetLocalRotation()
         {
-            return go.transform.localRotation;
+            return go.transform.localRotation.ToQuaternionf();
         }
 
 
         public virtual void SetLocalScale(Vector3f vScale)
         {
-            go.transform.localScale = vScale;
+            go.transform.localScale = vScale.ToVector3();
         }
         public virtual void SetLocalScale(float fScale)
         {
-            go.transform.localScale = fScale * Vector3f.One; 
+            go.transform.localScale = fScale * Vector3.one;
         }
         public virtual Vector3f GetLocalScale()
         {
-            return go.transform.localScale;
+            return go.transform.localScale.ToVector3f();
         }
 
 
@@ -306,20 +306,20 @@ namespace f3
 
 
         public virtual Vector3f PointToWorld(Vector3f local) {
-            return go.transform.TransformPoint(local);
+            return go.transform.TransformPoint(local.ToVector3()).ToVector3f();
         }
         public virtual Vector3f PointToLocal(Vector3f world) {
-            return go.transform.InverseTransformPoint(world);
+            return go.transform.InverseTransformPoint(world.ToVector3()).ToVector3f();
         }
 
 
         public virtual void RotateD(Vector3f axis, float fAngleDeg)
         {
-            go.transform.Rotate(axis, fAngleDeg);
+            go.transform.Rotate(axis.ToVector3(), fAngleDeg);
         }
         public virtual void RotateAroundD(Vector3f point, Vector3f axis, float fAngleDeg)
         {
-            go.transform.RotateAround(point, axis, fAngleDeg);
+            go.transform.RotateAround(point.ToVector3(), axis.ToVector3(), fAngleDeg);
         }
 
         // 05/09/2017 [RMS] just discovered that transform.Translate() default behavior
@@ -327,7 +327,7 @@ namespace f3
         // Exposed this as parameter, forcing callers to specify it for now.
         public virtual void Translate(Vector3f translation, bool bFrameAxes)
         {
-            go.transform.Translate(translation, bFrameAxes ? Space.Self : Space.World  );
+            go.transform.Translate(translation.ToVector3(), bFrameAxes ? Space.Self : Space.World  );
         }
 
 
@@ -887,10 +887,10 @@ namespace f3
 
         void LateUpdate()
         {
-            this.gameObject.transform.position = TrackGO.GetPosition();
-            this.gameObject.transform.rotation = TrackGO.GetRotation();
+            this.gameObject.transform.position = TrackGO.GetPosition().ToVector3();
+            this.gameObject.transform.rotation = TrackGO.GetRotation().ToQuaternion();
             if (TrackScale)
-                this.gameObject.transform.localScale = TrackGO.GetLocalScale();
+                this.gameObject.transform.localScale = TrackGO.GetLocalScale().ToVector3();
         }
     }
 

--- a/platform/fGameObjectFactory.cs
+++ b/platform/fGameObjectFactory.cs
@@ -279,7 +279,7 @@ namespace f3
             GameObject textGO = new GameObject(sName);
             TextMesh tm = textGO.AddComponent<TextMesh>();
             tm.text = sText;
-            tm.color = textColor;
+            tm.color = textColor.ToColor();
             tm.fontSize = 50;
             tm.offsetZ = fOffsetZ;
             tm.alignment = TextAlignment.Left;
@@ -288,7 +288,7 @@ namespace f3
             // use our textmesh material instead
             MaterialUtil.SetTextMeshDefaultMaterial(tm);
 
-            Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm);
+            Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm).ToVector2f();
             float fScaleH = fTextHeight / size.y;
             tm.transform.localScale = new Vector3(fScaleH, fScaleH, fScaleH);
             float fTextWidth = fScaleH * size.x;

--- a/platform/fGraph.cs
+++ b/platform/fGraph.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using g3;
 
@@ -33,7 +31,7 @@ namespace f3
             for (int i = 0; i < curve.VertexCount; ++i) {
                 indices[2 * i] = i;
                 indices[2 * i + 1] = (i + 1) % NV;
-                verts[i] = (Vector3)curve[i];
+                verts[i] = curve[i].ToVector3();
             }
             graph.vertices = verts;
 
@@ -45,7 +43,7 @@ namespace f3
                 for (int i = 0; i < curve.VertexCount; ++i) {
                     Vector3d tan = curve.Tangent(i);
                     vf.AlignAxis(2, (Vector3f)tan);
-                    normals[i] = vf.X;
+                    normals[i] = vf.X.ToVector3();
                     float s = (sizes == null) ? 1.0f : sizes[i];
                     tangents[i] = new Vector4(vf.Y.x, vf.Y.y, vf.Y.z, s);
                 }
@@ -57,7 +55,7 @@ namespace f3
             if ( colors != null ) { 
                 Color[] ucolors = new Color[NV];
                 for (int i = 0; i < curve.VertexCount; ++i)
-                    ucolors[i] = colors[i];
+                    ucolors[i] = colors[i].ToColor();
                 graph.colors = ucolors;
             }
 

--- a/platform/fMaterial.cs
+++ b/platform/fMaterial.cs
@@ -28,8 +28,8 @@ namespace f3
         }
 
         public virtual Colorf color {
-            get { return unityMat.color; }
-            set { unityMat.color = value; }
+            get { return unityMat.color.ToColorf(); }
+            set { unityMat.color = value.ToColor(); }
         }
 
         public virtual Texture mainTexture {
@@ -58,10 +58,10 @@ namespace f3
         }
 
         public virtual void SetVector(string identifier, Vector4f value) {
-            unityMat.SetVector(identifier, value);
+            unityMat.SetVector(identifier, value.ToVector4());
         }
         public virtual Vector4f GetVector(string identifier) {
-            return unityMat.GetVector(identifier);
+            return unityMat.GetVector(identifier).ToVector4f();
         }
 
 
@@ -95,11 +95,11 @@ namespace f3
         }
 
         public override Colorf color {
-            get { return unityMat.color; }
+            get { return unityMat.color.ToColorf(); }
             set {
                 bool alpha_change = (value.a == 1.0f && unityMat.color.a != 1.0f) ||
                                     (value.a != 1.0f && unityMat.color.a == 1.0f);
-                unityMat.color = value;
+                unityMat.color = value.ToColor();
                 if (alpha_change) {
                     DebugUtil.Log(2, "changing alpha to {0}", value.a);
                     if (value.a == 1) {

--- a/platform/fMesh.cs
+++ b/platform/fMesh.cs
@@ -34,7 +34,7 @@ namespace f3
             int NV = source_vertices.Length;
             Vector3[] vertices = new Vector3[NV];
             for ( int i = 0; i < NV; ++i ) {
-                vertices[i] = (Vector3)source.GetVertex(source_vertices[i]);
+                vertices[i] = source.GetVertex(source_vertices[i]).ToVector3();
             }
 
             Mesh m = new Mesh();
@@ -47,7 +47,7 @@ namespace f3
             if (bCopyNormals && source.HasVertexNormals) {
                 Vector3[] normals = new Vector3[NV];
                 for (int i = 0; i < NV; ++i)
-                    normals[i] =(Vector3)source.GetVertexNormal(source_vertices[i]);
+                    normals[i] = source.GetVertexNormal(source_vertices[i]).ToVector3();
                 m.normals = normals;
             } else {
                 m.RecalculateNormals();
@@ -56,14 +56,14 @@ namespace f3
             if ( bCopyColors && source.HasVertexColors ) {
                 Color[] colors = new Color[NV];
                 for ( int i = 0; i < NV; ++i )
-                    colors[i] = (Color)source.GetVertexColor(source_vertices[i]);
+                    colors[i] = source.GetVertexColor(source_vertices[i]).ToColor();
                 m.colors = colors;
             }
 
             if ( bCopyUVs && source.HasVertexUVs ) {
                 Vector2[] uvs = new Vector2[NV];
                 for ( int i = 0; i < NV; ++i )
-                    uvs[i] = source.GetVertexUV(source_vertices[i]);
+                    uvs[i] = source.GetVertexUV(source_vertices[i]).ToVector2();
                 m.uv = uvs;
             }
 
@@ -81,7 +81,7 @@ namespace f3
             for ( int i = 0; i < NV; ++i ) {
                 if (source.IsVertex(i))
                 {
-                    tempVertHolder.Add((Vector3)source.GetVertexUnsafe(i));
+                    tempVertHolder.Add(source.GetVertexUnsafe(i).ToVector3());
                 }
             }
 
@@ -91,7 +91,7 @@ namespace f3
                 Vector3[] normals = new Vector3[NV];
                 for (int i = 0; i < NV; ++i) {
                     if (source.IsVertex(i))
-                        normals[i] = (Vector3)source.GetVertexNormal(i);
+                        normals[i] = source.GetVertexNormal(i).ToVector3();
                 }
                 mesh.normals = normals;
             }
@@ -100,7 +100,7 @@ namespace f3
                 Color[] colors = new Color[NV];
                 for (int i = 0; i < NV; ++i) {
                     if (source.IsVertex(i))
-                        colors[i] = (Color)source.GetVertexColor(i);
+                        colors[i] = source.GetVertexColor(i).ToColor();
                 }
                 mesh.colors = colors;
             }
@@ -112,7 +112,7 @@ namespace f3
             int NV = source_vertices.Length;
             Vector3[] vertices = new Vector3[NV];
             for ( int i = 0; i < NV; ++i ) {
-                vertices[i] = (Vector3)source.GetVertexUnsafe(source_vertices[i]);
+                vertices[i] = source.GetVertexUnsafe(source_vertices[i]).ToVector3();
             }
 
             mesh.vertices = vertices;
@@ -120,14 +120,14 @@ namespace f3
             if (bCopyNormals && source.HasVertexNormals) {
                 Vector3[] normals = new Vector3[NV];
                 for (int i = 0; i < NV; ++i)
-                    normals[i] =(Vector3)source.GetVertexNormal(source_vertices[i]);
+                    normals[i] = source.GetVertexNormal(source_vertices[i]).ToVector3();
                 mesh.normals = normals;
             }
 
             if ( bCopyColors && source.HasVertexColors ) {
                 Color[] colors = new Color[NV];
                 for ( int i = 0; i < NV; ++i )
-                    colors[i] = (Color)source.GetVertexColor(source_vertices[i]);
+                    colors[i] = source.GetVertexColor(source_vertices[i]).ToColor();
                 mesh.colors = colors;
             }
         }
@@ -195,9 +195,9 @@ namespace f3
             public bool HasVertexNormals { get { return normals != null && normals.Length == vertices.Length; } }
             public bool HasVertexColors { get { return colors != null && colors.Length == vertices.Length; } }
 
-            public Vector3d GetVertex(int i) { return vertices[i]; }
-            public Vector3f GetVertexNormal(int i) { return normals[i]; }
-            public Vector3f GetVertexColor(int i) { return colors[i]; }
+            public Vector3d GetVertex(int i) { return vertices[i].ToVector3f(); }
+            public Vector3f GetVertexNormal(int i) { return normals[i].ToVector3f(); }
+            public Vector3f GetVertexColor(int i) { return colors[i].ToColorf(); }
 
             public bool IsVertex(int vID) { return vID >= 0 && vID < vertices.Length; }
 
@@ -209,7 +209,7 @@ namespace f3
 		    public int MaxTriangleID { get { return triangles.Length / 3; } }
 
             public bool HasVertexUVs { get { return uv != null && uv.Length == vertices.Length; } }
-            public Vector2f GetVertexUV(int i) { return uv[i]; }
+            public Vector2f GetVertexUV(int i) { return uv[i].ToVector2f(); }
 
             public NewVertexInfo GetVertexAll(int i) {
                 return new NewVertexInfo(GetVertex(i),

--- a/platform/fText.cs
+++ b/platform/fText.cs
@@ -76,7 +76,7 @@ namespace f3
         {
             switch (eType) {
                 case TextType.UnityTextMesh:
-                    (text_component as TextMesh).color = color;
+                    (text_component as TextMesh).color = color.ToColor();
                     break;
                 case TextType.TextMeshPro:
 #if G3_ENABLE_TEXT_MESH_PRO || F3_ENABLE_TEXT_MESH_PRO
@@ -92,8 +92,8 @@ namespace f3
             switch (eType) {
                 case TextType.UnityTextMesh: {
                         TextMesh tm = (text_component as TextMesh);
-                        tm.transform.localScale = Vector3f.One;
-                        Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm);
+                        tm.transform.localScale = Vector3.one;
+                        Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm).ToVector2f();
                         float fScaleH = fNewHeight / size.y;
                         tm.transform.localScale = new Vector3(fScaleH, fScaleH, fScaleH);
                         size = new Vector2f(fScaleH * size.x, fNewHeight);

--- a/sceneObjects/BaseSO.cs
+++ b/sceneObjects/BaseSO.cs
@@ -196,7 +196,7 @@ namespace f3
         {
             hit = null;
             GameObjectRayHit hitg = null;
-            if (FindGORayIntersection(ray, out hitg)) {
+            if (FindGORayIntersection(ray.ToRay(), out hitg)) {
                 if (hitg.hitGO != null) {
                     hit = new SORayHit(hitg, this);
                     return true;

--- a/sceneObjects/BoxSO.cs
+++ b/sceneObjects/BoxSO.cs
@@ -75,9 +75,9 @@ namespace f3
             //  translate along axis as well...
             Frame3f f = GetLocalFrame(CoordSpace.ObjectCoords);
             float fScale = box.transform.localScale[0];
-            f.Origin -= f.FromFrameV(fScale * centerShift);
+            f.Origin -= f.FromFrameV((fScale * centerShift).ToVector3f());
             update_shift();
-            f.Origin += f.FromFrameV(fScale * centerShift);
+            f.Origin += f.FromFrameV((fScale * centerShift).ToVector3f());
             SetLocalFrame(f, CoordSpace.ObjectCoords);
 
             // apparently this is expensive?

--- a/sceneObjects/CylinderSO.cs
+++ b/sceneObjects/CylinderSO.cs
@@ -93,9 +93,9 @@ namespace f3
             //  translate along axis as well...
             Frame3f f = GetLocalFrame(CoordSpace.ObjectCoords);
             float fScale = cylinder.transform.localScale[1];
-            f.Origin -= f.FromFrameV(fScale * centerShift);
+            f.Origin -= f.FromFrameV((fScale * centerShift).ToVector3f());
             update_shift();
-            f.Origin += f.FromFrameV(fScale * centerShift);
+            f.Origin += f.FromFrameV((fScale * centerShift).ToVector3f());
             SetLocalFrame(f, CoordSpace.ObjectCoords);
 
             // apparently this is expensive?
@@ -193,17 +193,17 @@ namespace f3
         {
             hit = null;
             GameObjectRayHit hitg = null;
-            if (FindGORayIntersection(ray, out hitg)) {
+            if (FindGORayIntersection(ray.ToRay(), out hitg)) {
                 if (hitg.hitGO != null) {
                     hit = new SORayHit(hitg, this);
 
                     // compute analytic normal on cylinder body
                     if ( hitg.hitGO == body ) {
-                        Vector3 up = this.RootGameObject.GetRotation() * Vector3.up;
-                        Vector3 l = hitg.hitPos - this.RootGameObject.GetPosition();
+                        Vector3 up = this.RootGameObject.GetRotation().ToQuaternion() * Vector3.up;
+                        Vector3 l = (hitg.hitPos - this.RootGameObject.GetPosition()).ToVector3();
                         l -= Vector3.Dot(l, up) * up;
                         l.Normalize();
-                        hit.hitNormal = l;
+                        hit.hitNormal = l.ToVector3f();
                     }
 
                     return true;

--- a/sceneObjects/MeshSO.cs
+++ b/sceneObjects/MeshSO.cs
@@ -88,8 +88,7 @@ namespace f3
 
         override public AxisAlignedBox3f GetLocalBoundingBox()
         {
-            AxisAlignedBox3f b = (AxisAlignedBox3f)meshGO.GetSharedMesh().bounds;
-            return b;
+            return meshGO.GetSharedMesh().bounds.ToAxisAlignedBox3f();
         }
 
 
@@ -121,7 +120,7 @@ namespace f3
 
             float[] signs = new float[m.vertexCount];
             for ( int i = 0; i < m.vertexCount; ++i ) {
-                Vector3f v = vertices[i];
+                Vector3f v = vertices[i].ToVector3f();
                 signs[i] = (v - f.Origin).Dot(up); 
             }
 
@@ -140,7 +139,7 @@ namespace f3
                 for ( int j = 0; j < 3; ++j ) {
                     ts[j] = signs[t[j]];
                     c += (int)Math.Sign(ts[j]);
-                    tv[j] = vertices[t[j]];
+                    tv[j] = vertices[t[j]].ToVector3f();
                 }
                 if (c == -3 || c == 3)
                     continue;

--- a/sceneObjects/PolyCurveSO.cs
+++ b/sceneObjects/PolyCurveSO.cs
@@ -148,7 +148,7 @@ namespace f3
                     int N = Nc;
                     Vector3[] vec = new Vector3[N];
                     for ( int i = 0; i < N; ++i )
-                        vec[i] = (Vector3)curve[ i % Nc ];
+                        vec[i] = curve[ i % Nc ].ToVector3();
                     ren.positionCount = N;
                     ren.SetPositions(vec);
                     ren.loop = (curve.Closed);

--- a/sceneObjects/PolyTubeSO.cs
+++ b/sceneObjects/PolyTubeSO.cs
@@ -97,8 +97,8 @@ namespace f3
             }
 
             // expand local bounds
-            add_to_bounds( newMesh.bounds.min);
-            add_to_bounds( newMesh.bounds.max);
+            add_to_bounds( newMesh.bounds.min.ToVector3f());
+            add_to_bounds( newMesh.bounds.max.ToVector3f());
         }
 
 
@@ -107,14 +107,14 @@ namespace f3
             hit = null;
 
             Frame3f frameW = GetLocalFrame(CoordSpace.WorldCoords);
-            Ray localRay = frameW.ToFrame(ray);
+            Ray localRay = frameW.ToFrame(ray).ToRay();
 
-            Bounds hitBounds = GetLocalBoundingBox();
+            Bounds hitBounds = GetLocalBoundingBox().ToBounds();
             if (hitBounds.IntersectRay(localRay) == false)
                 return false;
 
             GameObjectRayHit goHit;
-            if ( UnityUtil.FindGORayIntersection(ray, meshGO, out goHit) ) {
+            if ( UnityUtil.FindGORayIntersection(ray.ToRay(), meshGO, out goHit) ) {
                 hit = new SORayHit(goHit, this);
                 return true;
             }

--- a/sceneObjects/SphereSO.cs
+++ b/sceneObjects/SphereSO.cs
@@ -66,9 +66,9 @@ namespace f3
             //  translate along axis as well...
             Frame3f f = GetLocalFrame(CoordSpace.ObjectCoords);
             float fScale = sphere.transform.localScale[1];
-            f.Origin -= f.FromFrameV(fScale * centerShift);
+            f.Origin -= f.FromFrameV((fScale * centerShift).ToVector3f());
             update_shift();
-            f.Origin += f.FromFrameV(fScale * centerShift);
+            f.Origin += f.FromFrameV((fScale * centerShift).ToVector3f());
             SetLocalFrame(f, CoordSpace.ObjectCoords);
 
             // apparently this is expensive?
@@ -143,7 +143,7 @@ namespace f3
         {
             hit = null;
             GameObjectRayHit hitg = null;
-            if (FindGORayIntersection(ray, out hitg)) {
+            if (FindGORayIntersection(ray.ToRay(), out hitg)) {
                 if (hitg.hitGO != null) {
                     hit = new SORayHit(hitg, this);
 

--- a/serialization/SceneMeshExporter.cs
+++ b/serialization/SceneMeshExporter.cs
@@ -218,9 +218,9 @@ namespace f3
                 NewVertexInfo vi = new NewVertexInfo();
                 vi.bHaveN = WriteNormals; vi.bHaveC = WriteVertexColors; vi.bHaveUV = WriteUVs;
 
-                Vector3f v = vertices[i];
+                Vector3f v = vertices[i].ToVector3f();
                 // local to world
-                v = filter.gameObject.transform.TransformPoint(v);
+                v = filter.gameObject.transform.TransformPoint(v.ToVector3()).ToVector3f();
                 // world back to scene
                 v = scene.ToSceneP(v);
                 vi.v = MeshTransforms.FlipLeftRightCoordSystems(vi.v);
@@ -228,13 +228,13 @@ namespace f3
                 if (WriteNormals) {
                     Vector3 n = normals[i];
                     n = filter.gameObject.transform.TransformDirection(n);  // to world
-                    n = scene.ToSceneN(n);  // to scene
+                    n = scene.ToSceneN(n.ToVector3f()).ToVector3();  // to scene
                     vi.n = MeshTransforms.FlipLeftRightCoordSystems(vi.n);
                 }
                 if (WriteVertexColors)
-                    vi.c = colors[i];
+                    vi.c = colors[i].ToVector3f();
                 if (WriteUVs)
-                    vi.uv = uvs[i];
+                    vi.uv = uvs[i].ToVector2f();
 
                 vertexMap[i] = m.AppendVertex(vi);
             }

--- a/setup/SceneLightingSetup.cs
+++ b/setup/SceneLightingSetup.cs
@@ -43,7 +43,7 @@ namespace f3 {
 				GameObject lightObj = new GameObject (string.Format ("spotlight{0}", k));
 				Light lightComp = lightObj.AddComponent<Light> ();
 				lightComp.type = LightType.Directional;
-				lightComp.transform.position = vCornerPos;
+				lightComp.transform.position = vCornerPos.ToVector3();
 				lightComp.transform.LookAt (Vector3.zero);
 				lightComp.transform.RotateAround(Vector3.zero, Vector3.up, (float)k * rotAngle);
 
@@ -88,7 +88,7 @@ namespace f3 {
                 // use vertical height of light to figure out appropriate shadow distance.
                 // distance changes if we scale scene, and if we don't do this, shadow
                 // map res gets very blurry.
-                Vector3f thisW = lights[0].transform.position;
+                Vector3f thisW = lights[0].transform.position.ToVector3f();
                 float fHeight =
                     Vector3f.Dot((thisW - sceneFrameW.Origin), sceneFrameW.Y);
                 float fShadowDist = fHeight * 1.5f;
@@ -98,7 +98,7 @@ namespace f3 {
                     fShadowDist = LightDistance * 1.5f;
 
                 // need to be a multiple of eye distance
-                float fEyeDist = sceneFrameW.Origin.Distance(Camera.main.transform.position);
+                float fEyeDist = sceneFrameW.Origin.Distance(Camera.main.transform.position.ToVector3f());
                 fShadowDist = Mathf.Max(fShadowDist, 1.5f * fEyeDist);
 
                 int nShadowDist = (int)Snapping.SnapToIncrement(fShadowDist, 50);

--- a/tools/DrawPrimitivesTool.cs
+++ b/tools/DrawPrimitivesTool.cs
@@ -366,7 +366,7 @@ namespace f3
         {
             if (input.bLeftTriggerPressed ^ input.bRightTriggerPressed) {
                 CaptureSide eSide = (input.bLeftTriggerPressed) ? CaptureSide.Left : CaptureSide.Right;
-                Ray sideRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
+                Ray3f sideRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
                 ITool tool = context.ToolManager.GetActiveTool((int)eSide);
                 if (tool != null && tool is DrawPrimitivesTool) {
                     AnyRayHit rayHit;
@@ -379,13 +379,13 @@ namespace f3
 
         override public Capture BeginCapture(InputState input, CaptureSide eSide)
         {
-            Ray sideRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
+            Ray sideRay = (eSide == CaptureSide.Left) ? input.vLeftSpatialWorldRay.ToRay() : input.vRightSpatialWorldRay.ToRay();
             Frame3f sideHandF = (eSide == CaptureSide.Left) ? input.LeftHandFrame : input.RightHandFrame;
             DrawPrimitivesTool tool = context.ToolManager.GetActiveTool((int)eSide) as DrawPrimitivesTool;
 
             AnyRayHit rayHit;
-            if (context.Scene.FindSceneRayIntersection(sideRay, out rayHit)) {
-                tool.BeginDraw_Spatial(sideRay, rayHit, sideHandF, 0);
+            if (context.Scene.FindSceneRayIntersection(sideRay.ToRay3f(), out rayHit)) {
+                tool.BeginDraw_Spatial(sideRay.ToRay3f(), rayHit, sideHandF, 0);
                 return Capture.Begin(this, eSide, new capture_data() { nStep = 0 });
             }
             return Capture.Ignore;
@@ -404,11 +404,11 @@ namespace f3
                 return Capture.End;
             }
 
-            Ray sideRay = (data.which == CaptureSide.Left) ? input.vLeftSpatialWorldRay : input.vRightSpatialWorldRay;
+            Ray sideRay = (data.which == CaptureSide.Left) ? input.vLeftSpatialWorldRay.ToRay() : input.vRightSpatialWorldRay.ToRay();
             Frame3f sideHandF = (data.which == CaptureSide.Left) ? input.LeftHandFrame : input.RightHandFrame;
             capture_data cap = data.custom_data as capture_data;
 
-            tool.UpdateDraw_Spatial(sideRay, sideHandF, cap.nStep);
+            tool.UpdateDraw_Spatial(sideRay.ToRay3f(), sideHandF, cap.nStep);
 
             bool bReleased = (data.which == CaptureSide.Left) ? input.bLeftTriggerReleased : input.bRightTriggerReleased;
             if (bReleased) {

--- a/unity/UnityCurveRenderer.cs
+++ b/unity/UnityCurveRenderer.cs
@@ -39,7 +39,7 @@ namespace f3
             if (r.positionCount != Vertices.Length)
                 r.positionCount = Vertices.Length;
             for (int i = 0; i < Vertices.Length; ++i) 
-                r.SetPosition(i, Vertices[i]);
+                r.SetPosition(i, Vertices[i].ToVector3());
         }
         public virtual void update_num_points(int N)
         {
@@ -48,7 +48,7 @@ namespace f3
         }
         public virtual void update_position(int i, Vector3f v)
         {
-            r.SetPosition(i, v);
+            r.SetPosition(i, v.ToVector3());
         }
         public virtual void update_width(float width)
         {
@@ -61,7 +61,7 @@ namespace f3
         }
         public virtual void update_color(Colorf color)
         {
-            r.startColor = r.endColor = color;
+            r.startColor = r.endColor = color.ToColor();
         }
 
         public virtual void set_corner_quality(int n)
@@ -104,7 +104,7 @@ namespace f3
             //float near_plane_w = Camera.main.nearClipPlane * (float)Math.Tan(Camera.main.fieldOfView);
             //float near_pixel_w = Camera.main.pixelWidth / near_plane_w;
             float near_plane_pixel_deg = Camera.main.fieldOfView / Camera.main.pixelWidth;
-            float fWidth = VRUtil.GetVRRadiusForVisualAngle(center, Camera.main.transform.position, near_plane_pixel_deg);
+            float fWidth = VRUtil.GetVRRadiusForVisualAngle(center, Camera.main.transform.position.ToVector3f(), near_plane_pixel_deg);
             r.startWidth = r.endWidth = width * fWidth;
         }
 

--- a/unity/UnityLineRender_GL.cs
+++ b/unity/UnityLineRender_GL.cs
@@ -51,7 +51,7 @@ namespace f3
 
         public void OnPostRender()
         {
-            CurrentCameraPos = Camera.main.transform.position;
+            CurrentCameraPos = Camera.main.transform.position.ToVector3f();
 
             GL.PushMatrix();
 
@@ -89,7 +89,7 @@ namespace f3
                 try {
                     Transform transform = ((GameObject)go).transform;
                     GL.MultMatrix(transform.localToWorldMatrix);
-                    Vector3f localCam = transform.InverseTransformPoint(CurrentCameraPos);
+                    Vector3f localCam = transform.InverseTransformPoint(CurrentCameraPos.ToVector3()).ToVector3f();
                     if (lines.WidthType == LineWidthType.Pixel) {
                         if (lines.Width == 1)
                             draw_lines(lines, localCam);
@@ -113,12 +113,12 @@ namespace f3
         {
 
             GL.Begin(GL.LINES);
-            GL.Color(lines.Color);
+            GL.Color(lines.Color.ToColor());
             int NS = lines.Segments.Count;
             for ( int k = 0; k < NS; ++k) {
                 Segment3d seg = lines.Segments[k];
-                GL.Vertex((Vector3)seg.P0);
-                GL.Vertex((Vector3)seg.P1);
+                GL.Vertex(seg.P0.ToVector3());
+                GL.Vertex(seg.P1.ToVector3());
             }
             GL.End();
 
@@ -126,12 +126,12 @@ namespace f3
             for ( int k = 0; k < NC; ++k ) {
                 DCurve3 c = lines.Curves[k];
                 GL.Begin(GL.LINE_STRIP);
-                GL.Color(lines.Color);
+                GL.Color(lines.Color.ToColor());
                 int NV = c.VertexCount;
                 for (int i = 0; i < NV; ++i)
-                    GL.Vertex((Vector3)c[i]);
+                    GL.Vertex(c[i].ToVector3());
                 if (c.Closed)
-                    GL.Vertex((Vector3)c[0]);
+                    GL.Vertex(c[0].ToVector3());
                 GL.End();
             }
         }
@@ -140,7 +140,7 @@ namespace f3
         void draw_quads(LineSet lines, Vector3f cameraPos)
         {
             GL.Begin(GL.QUADS);
-            GL.Color(lines.Color);
+            GL.Color(lines.Color.ToColor());
 
             int NS = lines.Segments.Count;
             for (int k = 0; k < NS; ++k) {
@@ -189,10 +189,10 @@ namespace f3
             Vector3f perp = lineDir.Cross(eyeDir);
             perp.Normalize();
 
-            GL.Vertex(start - width * perp);
-            GL.Vertex(start + width * perp);
-            GL.Vertex(end + width * perp);
-            GL.Vertex(end - width * perp);
+            GL.Vertex((start - width * perp).ToVector3());
+            GL.Vertex((start + width * perp).ToVector3());
+            GL.Vertex((end + width * perp).ToVector3());
+            GL.Vertex((end - width * perp).ToVector3());
         }
 
 
@@ -201,10 +201,10 @@ namespace f3
         {
             Vector3f lineDir = end - start;
             Vector3f perp = lineDir.UnitCross(normal);
-            GL.Vertex(start - width * perp);
-            GL.Vertex(start + width * perp);
-            GL.Vertex(end + width * perp);
-            GL.Vertex(end - width * perp);
+            GL.Vertex((start - width * perp).ToVector3());
+            GL.Vertex((start + width * perp).ToVector3());
+            GL.Vertex((end + width * perp).ToVector3());
+            GL.Vertex((end - width * perp).ToVector3());
         }
 
 

--- a/unity/UnitySOMaterial.cs
+++ b/unity/UnitySOMaterial.cs
@@ -29,8 +29,8 @@ namespace f3
         }
 
         public override Colorf RGBColor {
-            get { return unityMaterial.color; }
-            set { unityMaterial.color = value; }
+            get { return unityMaterial.color.ToColorf(); }
+            set { unityMaterial.color = value.ToColor(); }
         }
 
         public override Texture2D MainTexture

--- a/unity/UnitySceneUtil.cs
+++ b/unity/UnitySceneUtil.cs
@@ -67,7 +67,7 @@ namespace f3
                 throw new Exception("UnitySceneUtil.ImportExistingUnityMesh: nonuniform scaling is not supported...");
 
             Mesh useMesh = meshF.mesh;      // makes a copy
-            AxisAlignedBox3f bounds = useMesh.bounds;       // bounds.Center is wrt local frame of input go
+            AxisAlignedBox3f bounds = useMesh.bounds.ToAxisAlignedBox3f();       // bounds.Center is wrt local frame of input go
                                                             // ie offset from origin in local coordinates
 
             // if we want to move frame to center of mesh, we have to re-center it at origin

--- a/unity/UnityUIUtil.cs
+++ b/unity/UnityUIUtil.cs
@@ -132,7 +132,7 @@ namespace f3
         public static void SetDisabledColor(Button button, Colorf color)
         {
             var newColorBlock = button.colors;
-            newColorBlock.disabledColor = color;
+            newColorBlock.disabledColor = color.ToColor();
             button.colors = newColorBlock;
         }
 
@@ -140,9 +140,9 @@ namespace f3
         public static void SetColors(Button button, Colorf normalColor, Colorf disabledColor)
         {
             var newColorBlock = button.colors;
-            newColorBlock.normalColor = normalColor;
-            newColorBlock.highlightedColor = ColorMixer.Darken(normalColor, 0.9f);
-            newColorBlock.disabledColor = disabledColor;
+            newColorBlock.normalColor = normalColor.ToColor();
+            newColorBlock.highlightedColor = ColorMixer.Darken(normalColor, 0.9f).ToColor();
+            newColorBlock.disabledColor = disabledColor.ToColor();
             button.colors = newColorBlock;
         }
 
@@ -445,20 +445,20 @@ namespace f3
         public static AxisAlignedBox2f GetBounds2D(GameObject go)
         {
             RectTransform rectT = go.GetComponent<RectTransform>();
-            AxisAlignedBox2f box = rectT.rect;
-            box.Translate(rectT.anchoredPosition);
+            AxisAlignedBox2f box = rectT.rect.ToAxisAlignedBox2f();
+            box.Translate(rectT.anchoredPosition.ToVector2f());
             return box;
         }
         public static AxisAlignedBox2f GetBounds2D(RectTransform rectT)
         {
-            AxisAlignedBox2f box = rectT.rect;
-            box.Translate(rectT.anchoredPosition);
+            AxisAlignedBox2f box = rectT.rect.ToAxisAlignedBox2f();
+            box.Translate(rectT.anchoredPosition.ToVector2f());
             return box;
         }
 
         public static void Translate(RectTransform rectT, Vector2f translate)
         {
-            rectT.anchoredPosition = (Vector2f)rectT.anchoredPosition + translate;
+            rectT.anchoredPosition = rectT.anchoredPosition + translate.ToVector2();
         }
 
 
@@ -726,7 +726,7 @@ namespace f3
             Text = "(label)";
             TextAlign = TextAlignment.Center;
             Scale = 0.1f;
-            Translate = new Vector3f(0, 0, 0);
+            Translate = new Vector3(0, 0, 0);
             Color = ColorUtil.make(10, 10, 10);
             ZOffset = -1.0f;
         }
@@ -737,14 +737,14 @@ namespace f3
 
             TextMesh tm = gameObj.AddComponent<TextMesh>();
             tm.text = Text;
-            tm.color = Color;
+            tm.color = Color.ToColor();
             tm.fontSize = 50;
             tm.offsetZ = ZOffset;
             tm.alignment = TextAlign;
 
             // [RMS] this isn't quite right, on the vertical centering...
-            Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm);
-            Vector3 vCenterShift = Vector3f.Zero;
+            Vector2f size = UnityUtil.EstimateTextMeshDimensions(tm).ToVector2f();
+            Vector3 vCenterShift = Vector3.zero;
             if (Align == Alignment.HCenter || Align == Alignment.HVCenter)
                 vCenterShift.x -= size.x * 0.5f;
             if (Align == Alignment.VCenter || Align == Alignment.HVCenter)

--- a/util/DebugUtil.cs
+++ b/util/DebugUtil.cs
@@ -110,7 +110,7 @@ namespace f3
 			GameObject box = GameObject.CreatePrimitive (PrimitiveType.Cube);
 			box.SetName(name);
 			box.transform.position = center;
-            box.transform.localScale = dims;
+            box.transform.localScale = dims.ToVector3();
 			box.GetComponent<MeshRenderer> ().material.color = color;
 			return box;
 		}
@@ -131,14 +131,14 @@ namespace f3
 
 			GameObject line = new GameObject ();
 			line.SetName(name);
-            line.transform.position = (bIsInWorldPos) ? start : Vector3f.Zero;
+            line.transform.position = (bIsInWorldPos) ? start.ToVector3() : Vector3.zero;
 			line.AddComponent<LineRenderer> ();
 			LineRenderer lr = line.GetComponent<LineRenderer> ();
 			lr.material = MaterialUtil.CreateParticlesMaterial();
-            lr.startColor = lr.endColor = color;
+            lr.startColor = lr.endColor = color.ToColor();
             lr.startWidth = lr.endWidth = diameter;
-			lr.SetPosition (0, start);
-			lr.SetPosition (1, end);
+			lr.SetPosition (0, start.ToVector3());
+			lr.SetPosition (1, end.ToVector3());
 
             if (parent != null) {
                 lr.useWorldSpace = bIsInWorldPos;
@@ -157,15 +157,15 @@ namespace f3
 
             GameObject line = new GameObject();
             line.SetName(name);
-            line.transform.position =  (bIsInWorldPos) ? start : Vector3f.Zero;
+            line.transform.position =  (bIsInWorldPos) ? start.ToVector3() : Vector3.zero;
             line.AddComponent<LineRenderer>();
             LineRenderer lr = line.GetComponent<LineRenderer>();
             lr.material = MaterialUtil.CreateParticlesMaterial();
-            lr.startColor = startColor;
-            lr.endColor = endColor;
+            lr.startColor = startColor.ToColor();
+            lr.endColor = endColor.ToColor();
             lr.startWidth = lr.endWidth = diameter;
-            lr.SetPosition(0, start);
-            lr.SetPosition(1, end);
+            lr.SetPosition(0, start.ToVector3());
+            lr.SetPosition(1, end.ToVector3());
 
             if (parent != null) {
                 lr.useWorldSpace = bIsInWorldPos;
@@ -189,12 +189,12 @@ namespace f3
 			line.AddComponent<LineRenderer> ();
 			LineRenderer lr = line.GetComponent<LineRenderer> ();
 			lr.material = MaterialUtil.CreateParticlesMaterial();
-            lr.startColor = startColor;
-            lr.endColor = endColor;
+            lr.startColor = startColor.ToColor();
+            lr.endColor = endColor.ToColor();
             lr.startWidth = lr.endWidth = diameter;
             Vector3[] verts = new Vector3[curve.Length];
             for (int i = 0; i < curve.Length; ++i)
-                verts[i] = (Vector3)curve[i];
+                verts[i] = ((Vector3f)curve[i]).ToVector3();
             lr.positionCount = curve.Length;
             lr.SetPositions(verts);
             lr.loop = bClosed;
@@ -215,9 +215,9 @@ namespace f3
             }
 
 			GameObject frameObj = new GameObject (name);
-			/*GameObject x = */EmitDebugLine (name+"_x", f.Origin, f.Origin + fAxisLength * f.X, diameter, Color.red, frameObj, false);
-			/*GameObject y = */EmitDebugLine (name+"_y", f.Origin, f.Origin + fAxisLength * f.Y, diameter, Color.green, frameObj, false);
-			/*GameObject z = */EmitDebugLine (name+"_z", f.Origin, f.Origin + fAxisLength * f.Z, diameter, Color.blue, frameObj, false);
+			/*GameObject x = */EmitDebugLine (name+"_x", f.Origin, f.Origin + fAxisLength * f.X, diameter, Colorf.Red, frameObj, false);
+			/*GameObject y = */EmitDebugLine (name+"_y", f.Origin, f.Origin + fAxisLength * f.Y, diameter, Colorf.Green, frameObj, false);
+			/*GameObject z = */EmitDebugLine (name+"_z", f.Origin, f.Origin + fAxisLength * f.Z, diameter, Colorf.Blue, frameObj, false);
             if (parent != null)
                 frameObj.transform.SetParent(parent.transform, false);
             return frameObj;
@@ -268,7 +268,7 @@ namespace f3
                         (FContext.ActiveContext_HACK.MouseCameraController as VRMouseCursorController).CurrentCursorPosWorld;
                 sphere.transform.localScale = new Vector3(diameter, diameter, diameter);
                 sphere.GetComponent<MeshRenderer>().material =
-                    MaterialUtil.CreateTransparentMaterial(color, 0.5f);
+                    MaterialUtil.CreateTransparentMaterial(color.ToVector3f(), 0.5f);
                 MaterialUtil.DisableShadows(sphere);
                 sphere.SetLayer(FPlatform.HUDLayer);
                 return sphere;
@@ -323,7 +323,7 @@ namespace f3
                 Vector3 local_scale = cur.transform.localScale;
 
                 Vector3 pos = cur.transform.position;
-                Vector3f angles = cur.transform.eulerAngles;
+                Vector3f angles = cur.transform.eulerAngles.ToVector3f();
 
                 string s = string.Format("go: {0}   local scale {1} pos {2} angles {3}     POS {4} ANGLES {5}",
                     cur.name, local_scale, local_pos, local_angles, pos, angles);

--- a/util/MaterialUtil.cs
+++ b/util/MaterialUtil.cs
@@ -17,12 +17,12 @@ namespace f3
 
         public static Material CreateStandardMaterial(Colorf c) {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultStandardMaterialPath);
-            m.color = c;
+            m.color = c.ToColor();
             return m;
         }
         public static fMaterial CreateStandardMaterialF(Colorf c) {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultStandardMaterialPath);
-            m.color = c;
+            m.color = c.ToColor();
             return new fMaterial(m);
         }
 
@@ -30,13 +30,13 @@ namespace f3
         public static Material CreateStandardVertexColorMaterial(Colorf c)
         {
             Material m = SafeLoadMaterial("StandardMaterials/default_vertex_colored");
-            m.color = c;
+            m.color = c.ToColor();
             return m;
         }
         public static fMaterial CreateStandardVertexColorMaterialF(Colorf c)
         {
             Material m = SafeLoadMaterial("StandardMaterials/default_vertex_colored");
-            m.color = c;
+            m.color = c.ToColor();
             return new fMaterial(m);
         }
 
@@ -45,7 +45,7 @@ namespace f3
         public static fMaterial CreateFlatShadedVertexColorMaterialF(Colorf c)
         {
             Material m = SafeLoadMaterial("StandardMaterials/flat_vertex_colored");
-            m.color = c;
+            m.color = c.ToColor();
             return new fMaterial(m);
         }
 
@@ -70,25 +70,25 @@ namespace f3
         public static Material CreateTransparentMaterial(Colorf c)
         {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultTransparentMaterialPath);
-            m.color = c;
+            m.color = c.ToColor();
             return m;
         }
         public static fMaterial CreateTransparentMaterialF(Colorf c)
         {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultTransparentMaterialPath);
-            m.color = c;
+            m.color = c.ToColor();
             return new fMaterial(m);
         }
 
         public static Material CreateTransparentMaterial(Colorf c, float alpha) {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultTransparentMaterialPath);
-            m.color = MakeColor(c, alpha);
+            m.color = MakeColor(c, alpha).ToColor();
             return m;
         }
         public static fMaterial CreateTransparentMaterialF(Colorf c, float alpha)
         {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultTransparentMaterialPath);
-            m.color = MakeColor(c, alpha);
+            m.color = MakeColor(c, alpha).ToColor();
             return new fMaterial(m);
         }
 
@@ -96,7 +96,7 @@ namespace f3
         public static fDynamicTransparencyMaterial CreateDynamicTransparencyMaterialF(Colorf c)
         {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultStandardMaterialPath);
-            m.color = c;
+            m.color = c.ToColor();
             return new fDynamicTransparencyMaterial(m);
         }
 
@@ -123,7 +123,7 @@ namespace f3
         public static Material CreateTransparentImageMaterial(string sResourcePath)
         {
             Material m = SafeLoadMaterial(SceneGraphConfig.DefaultUnlitTextureTransparentMaterialPath);
-            m.color = Colorf.White;
+            m.color = Color.white;
             Texture2D tex = SafeLoadTexture2D(sResourcePath);
             m.mainTexture = tex;
             return m;
@@ -149,7 +149,7 @@ namespace f3
             m.SetFloat("_FalloffWidth", falloff);
             m.SetVector("_Center", new Vector4(0, 0, 0, 0));
             m.SetVector("_Extents", new Vector4(w/2, h/2, 0, 0));
-            m.color = c;
+            m.color = c.ToColor();
             return new fMaterial(m);
         }
 
@@ -318,7 +318,7 @@ namespace f3
         {
             SOMaterial soMat = new SOMaterial();
             soMat.Name = unityMat.name;
-            soMat.RGBColor = unityMat.color;
+            soMat.RGBColor = unityMat.color.ToColorf();
 
             string tag = unityMat.GetTag("RenderType", true);
             bool bTransparent = (unityMat.color.a < 1 || tag == "Transparent");
@@ -342,7 +342,7 @@ namespace f3
             if (m.Type == SOMaterial.MaterialType.TextureMap) {
                 unityMat = new Material(Shader.Find("Standard"));
                 unityMat.SetName(m.Name);
-                unityMat.color = m.RGBColor;
+                unityMat.color = m.RGBColor.ToColor();
                 //if (m.Alpha < 1.0f)
                 //    MaterialUtil.SetupMaterialWithBlendMode(unityMat, MaterialUtil.BlendMode.Transparent);
                 unityMat.mainTexture = m.MainTexture;
@@ -384,7 +384,7 @@ namespace f3
                 unityMat = (m as UnitySOMaterial).unityMaterial;
 
             } else {
-                unityMat = MaterialUtil.CreateStandardMaterial(Color.black);
+                unityMat = MaterialUtil.CreateStandardMaterial(Colorf.Black);
             }
 
             if ( (m.Hints & SOMaterial.HintFlags.UseTransparentPass) != 0)
@@ -451,7 +451,7 @@ namespace f3
                 unityMat = (m as UnitySOMaterial).unityMaterial;
 
             } else {
-                unityMat = MaterialUtil.CreateStandardMaterial(Color.black);
+                unityMat = MaterialUtil.CreateStandardMaterial(Colorf.Black);
             }
 
             if ((m.Hints & SOMaterial.HintFlags.UseTransparentPass) != 0) {

--- a/util/MeshGenerators.cs
+++ b/util/MeshGenerators.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
 using g3;
 
 namespace f3 {
@@ -11,8 +9,62 @@ namespace f3 {
         public static fMesh MakeUnityMesh(this MeshGenerator gen, bool bRecalcNormals = false, bool bFlipLR = false)
         {
             Mesh m = new Mesh();
-            gen.MakeMesh(m, bRecalcNormals, bFlipLR);
+            MakeMesh(gen, m, bRecalcNormals, bFlipLR);
             return new fMesh(m);
+        }
+
+        /// <summary>
+        /// copy generated mesh data into a Unity Mesh object
+        /// </summary>
+        private static void MakeMesh(MeshGenerator gen, Mesh m, bool bRecalcNormals = false, bool bFlipLR = false)
+        {
+            m.vertices = ToUnityVector3(gen.vertices, bFlipLR);
+            if (gen.uv != null && gen.WantUVs)
+                m.uv = ToUnityVector2(gen.uv);
+            if (gen.normals != null && gen.WantNormals)
+                m.normals = ToUnityVector3(gen.normals, bFlipLR);
+            if (m.vertexCount > 64000 || gen.triangles.Count > 64000)
+                m.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            m.triangles = gen.triangles.array;
+            if (bRecalcNormals)
+                m.RecalculateNormals();
+        }
+
+        private static Vector3[] ToUnityVector3(VectorArray3f a, bool bFlipLR = false)
+        {
+            Vector3[] v = new Vector3[a.Count];
+            float fZSign = (bFlipLR) ? -1 : 1;
+            for (int i = 0; i < a.Count; ++i)
+            {
+                v[i].x = a.array[3 * i];
+                v[i].y = a.array[3 * i + 1];
+                v[i].z = fZSign * a.array[3 * i + 2];
+            }
+            return v;
+        }
+
+        private static Vector3[] ToUnityVector3(VectorArray3d a, bool bFlipLR = false)
+        {
+            Vector3[] v = new Vector3[a.Count];
+            float fZSign = (bFlipLR) ? -1 : 1;
+            for (int i = 0; i < a.Count; ++i)
+            {
+                v[i].x = (float)a.array[3 * i];
+                v[i].y = (float)a.array[3 * i + 1];
+                v[i].z = (float)(fZSign * a.array[3 * i + 2]);
+            }
+            return v;
+        }
+
+        private static Vector2[] ToUnityVector2(VectorArray2f a)
+        {
+            Vector2[] v = new Vector2[a.Count];
+            for (int i = 0; i < a.Count; ++i)
+            {
+                v[i].x = a.array[2 * i];
+                v[i].y = a.array[2 * i + 1];
+            }
+            return v;
         }
     }
 

--- a/util/MeshPrimitivePreview.cs
+++ b/util/MeshPrimitivePreview.cs
@@ -165,7 +165,7 @@ namespace f3
             meshObject.transform.localRotation = Quaternion.identity;
 
             // default unity cylinder is diam=1, height=2
-            meshObject.transform.localScale = new Vector3f(fAbsWidth, fAbsHeight / 2.0f, fAbsDepth);
+            meshObject.transform.localScale = new Vector3(fAbsWidth, fAbsHeight / 2.0f, fAbsDepth);
 
             shiftedFrame = Frame.Translated(Frame.FromFrameV(vShift));
             UnityUtil.SetGameObjectFrame(meshObject, shiftedFrame, CoordSpace.WorldCoords);
@@ -203,7 +203,7 @@ namespace f3
             meshObject.transform.localRotation = Quaternion.identity;
 
             // default unity box is 1x1x1 cube
-            meshObject.transform.localScale = new Vector3f(fAbsWidth, fAbsHeight, fAbsDepth);
+            meshObject.transform.localScale = new Vector3(fAbsWidth, fAbsHeight, fAbsDepth);
 
             shiftedFrame = Frame.Translated(Frame.FromFrameV(vShift));
             UnityUtil.SetGameObjectFrame(meshObject, shiftedFrame, CoordSpace.WorldCoords);
@@ -237,7 +237,7 @@ namespace f3
             meshObject.transform.localRotation = Quaternion.identity;
 
             // default unity sphere is diam=1
-            meshObject.transform.localScale = new Vector3f(fAbsWidth, fAbsWidth, fAbsWidth);
+            meshObject.transform.localScale = new Vector3(fAbsWidth, fAbsWidth, fAbsWidth);
 
             shiftedFrame = Frame.Translated(Frame.FromFrameV(vShift));
             UnityUtil.SetGameObjectFrame(meshObject, shiftedFrame, CoordSpace.WorldCoords);

--- a/util/UnityG3Convert.cs
+++ b/util/UnityG3Convert.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace f3
 {
-    public static class g3ToUnityConvert
+    public static class UnityG3Convert
     {
         public static Vector3f ToVector3f(this Vector3 v) => new Vector3f(v.x, v.y, v.z);
 
@@ -44,6 +44,7 @@ namespace f3
         public static Ray ToRay(this Ray3f r) => new Ray(r.Origin.ToVector3(), r.Direction.ToVector3());
 
         public static AxisAlignedBox2f ToAxisAlignedBox2f(this Rect rect) => new AxisAlignedBox2f(rect.min.ToVector2f(), rect.max.ToVector2f());
+        
         public static Rect ToRect(this AxisAlignedBox2f axisAlignedBox)
         {
             Rect ub = new Rect();
@@ -53,6 +54,7 @@ namespace f3
         }
 
         public static AxisAlignedBox3f ToAxisAlignedBox3f(this Bounds bounds) => new AxisAlignedBox3f(bounds.min.ToVector3f(), bounds.max.ToVector3f());
+        
         public static Bounds ToBounds(this AxisAlignedBox3f axisAlignedBox)
         {
             Bounds ub = new Bounds();

--- a/util/UnityGameObjectExt.cs
+++ b/util/UnityGameObjectExt.cs
@@ -134,7 +134,7 @@ namespace f3
         {
             Renderer r = go.GetComponent<Renderer>();
             if (r != null)
-                return r.material.color;
+                return r.material.color.ToColorf();
             return Colorf.White;
         }
 
@@ -202,20 +202,20 @@ namespace f3
 
         public static Vector3f GetLocalScale(this GameObject go)
         {
-            return go.transform.localScale;
+            return go.transform.localScale.ToVector3f();
         }
         public static void SetLocalScale(this GameObject go, Vector3f scale)
         {
-            go.transform.localScale = scale;
+            go.transform.localScale = scale.ToVector3();
         }
 
         public static Vector3f GetLocalPosition(this GameObject go)
         {
-            return go.transform.localPosition;
+            return go.transform.localPosition.ToVector3f();
         }
         public static void SetLocalPosition(this GameObject go, Vector3f position)
         {
-            go.transform.localPosition = position;
+            go.transform.localPosition = position.ToVector3();
         }
 
 
@@ -249,11 +249,11 @@ namespace f3
 
         public static void SetColor(this Material mat, Colorf color)
         {
-            mat.color = color;
+            mat.color = color.ToColor();
         }
         public static Colorf GetColor(this Material mat)
         {
-            return new Colorf(mat.color);
+            return new Colorf(mat.color.ToColorf());
         }
 
         public static void SetRenderStage(this Material mat, RenderStage eStage)

--- a/util/UnityUtil.cs
+++ b/util/UnityUtil.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using UnityEngine;
 using g3;
 
@@ -40,7 +42,7 @@ namespace f3
                 (gameObj.AddComponent(typeof(MeshRenderer)) as MeshRenderer).material = setMaterial;
             } else {
                 (gameObj.AddComponent(typeof(MeshRenderer)) as MeshRenderer).material =
-                    MaterialUtil.CreateStandardMaterial(Color.red);
+                    MaterialUtil.CreateStandardMaterial(Colorf.Red);
             }
             return gameObj;
         }
@@ -97,20 +99,20 @@ namespace f3
         public static Frame3f GetGameObjectFrame(GameObject go, CoordSpace eSpace)
         {
             if (eSpace == CoordSpace.WorldCoords)
-                return new Frame3f(go.transform.position, go.transform.rotation);
+                return new Frame3f(go.transform.position.ToVector3f(), go.transform.rotation.ToQuaternionf());
             else if (eSpace == CoordSpace.ObjectCoords)
-                return new Frame3f(go.transform.localPosition, go.transform.localRotation);
+                return new Frame3f(go.transform.localPosition.ToVector3f(), go.transform.localRotation.ToQuaternionf());
             else
                 throw new ArgumentException("not possible without refernce to scene!");
         }
         public static void SetGameObjectFrame(GameObject go, Frame3f newFrame, CoordSpace eSpace)
         {
             if (eSpace == CoordSpace.WorldCoords) {
-                go.transform.position = newFrame.Origin;
-                go.transform.rotation = newFrame.Rotation;
+                go.transform.position = newFrame.Origin.ToVector3();
+                go.transform.rotation = newFrame.Rotation.ToQuaternion();
             } else if (eSpace == CoordSpace.ObjectCoords) {
-                go.transform.localPosition = newFrame.Origin;
-                go.transform.localRotation = newFrame.Rotation;
+                go.transform.localPosition = newFrame.Origin.ToVector3();
+                go.transform.localRotation = newFrame.Rotation.ToQuaternion();
             } else {
                 // [RMS] cannot do this w/o handle to scene...
                 Debug.Log("[MathUtil.SetGameObjectFrame] unsupported!\n");
@@ -174,8 +176,8 @@ namespace f3
             if (collider.Raycast(ray, out hitInfo, Mathf.Infinity)) {
                 hit = new GameObjectRayHit();
                 hit.fHitDist = hitInfo.distance;
-                hit.hitPos = hitInfo.point;
-                hit.hitNormal = hitInfo.normal;
+                hit.hitPos = hitInfo.point.ToVector3f();
+                hit.hitNormal = hitInfo.normal.ToVector3f();
                 hit.hitGO = go;
             }
             go.EnableCollider(bIsEnabled);
@@ -189,7 +191,7 @@ namespace f3
         {
             Renderer r = go.GetComponent<Renderer>();
             if (r != null) {
-                return r.bounds;
+                return r.bounds.ToAxisAlignedBox3f();
             } else if ( go.HasChildren() ) {
                 AxisAlignedBox3f b = AxisAlignedBox3f.Empty; int i = 0;
                 foreach (GameObject child_go in go.Children()) {
@@ -200,7 +202,7 @@ namespace f3
                 }
                 return b;
             } else {
-                return new AxisAlignedBox3f(go.transform.position, new Vector3(0.001f, 0.001f, 0.001f));
+                return new AxisAlignedBox3f(go.transform.position.ToVector3f(), new Vector3f(0.001f, 0.001f, 0.001f));
             }
         }
 
@@ -227,7 +229,7 @@ namespace f3
         /// </summary>
         public static AxisAlignedBox3f GetGeometryBoundingBox(GameObject go, bool bIncludeChildren = false) {
             MeshFilter f = go.GetComponent<MeshFilter>();
-            AxisAlignedBox3f b = (f != null) ? (AxisAlignedBox3f)f.mesh.bounds : AxisAlignedBox3f.Empty;
+            AxisAlignedBox3f b = (f != null) ? f.mesh.bounds.ToAxisAlignedBox3f() : AxisAlignedBox3f.Empty;
 
             if ( bIncludeChildren && go.HasChildren() ) {
                 foreach (GameObject child_go in go.Children()) {
@@ -359,8 +361,8 @@ namespace f3
         {
             Vector3[] verts = m.vertices;
             for ( int k = 0; k < verts.Length; ++k ) {
-                Vector3f v = verts[k];
-                verts[k] = q * (v - center) + center;
+                Vector3f v = verts[k].ToVector3f();
+                verts[k] = (q * (v - center) + center).ToVector3();
             }
             m.vertices = verts;
         }
@@ -369,8 +371,8 @@ namespace f3
         {
             Vector3[] verts = m.vertices;
             for ( int k = 0; k < verts.Length; ++k ) {
-                Vector3f v = verts[k];
-                verts[k] = scale * (v - center) + center;
+                Vector3f v = verts[k].ToVector3f();
+                verts[k] = (scale * (v - center) + center).ToVector3();
             }
             m.vertices = verts;
         }
@@ -627,11 +629,11 @@ namespace f3
                     if (bByteColors)
                         vInfo.c = new Colorf(colors32[i].r, colors32[i].g, colors32[i].b, 255);
                     else
-                        vInfo.c = colors[i];
+                        vInfo.c = colors[i].ToVector3f();
                 }
                 if ( bUVs ) {
                     vInfo.bHaveUV = true;
-                    vInfo.uv = uv[i];
+                    vInfo.uv = uv[i].ToVector2f();
                 }
 
                 int vid = dmesh.AppendVertex(vInfo);
@@ -652,7 +654,7 @@ namespace f3
         {
             Vector3[] meshV = new Vector3[vNewPositions.Length];
             for (int i = 0; i < vNewPositions.Length; ++i)
-                meshV[i] = vNewPositions[i];
+                meshV[i] = vNewPositions[i].ToVector3();
             unityMesh.vertices = meshV;
 
             if (bRecalcNormals)
@@ -662,7 +664,7 @@ namespace f3
         {
             Vector3[] meshV = new Vector3[vNewPositions.Length];
             for (int i = 0; i < vNewPositions.Length; ++i)
-                meshV[i] = (Vector3f)vNewPositions[i];
+                meshV[i] = ((Vector3f)vNewPositions[i]).ToVector3();
             unityMesh.vertices = meshV;
 
             if (bRecalcNormals)

--- a/util/UnityUtil.cs
+++ b/util/UnityUtil.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using g3;
 
@@ -550,7 +548,7 @@ namespace f3
 
 
             for ( int i = 0; i < mesh.vertexCount; ++i ) {
-                Vector3d v = vertices[i];
+                Vector3d v = vertices[i].ToVector3f();
                 if (bSwapLeftRight) {
                     v.x = -v.x;
                     v.z = -v.z;
@@ -558,7 +556,7 @@ namespace f3
                 NewVertexInfo vInfo = new NewVertexInfo(v);
                 if ( bNormals ) {
                     vInfo.bHaveN = true;
-                    vInfo.n = normals[i];
+                    vInfo.n = normals[i].ToVector3f();
                     if (bSwapLeftRight) {
                         vInfo.n.x = -vInfo.n.x;
                         vInfo.n.z = -vInfo.n.z;
@@ -569,11 +567,11 @@ namespace f3
                     if (bByteColors)
                         vInfo.c = new Colorf(colors32[i].r, colors32[i].g, colors32[i].b, 255);
                     else
-                        vInfo.c = colors[i];
+                        vInfo.c = colors[i].ToVector3f();
                 }
                 if ( bUVs ) {
                     vInfo.bHaveUV = true;
-                    vInfo.uv = uv[i];
+                    vInfo.uv = uv[i].ToVector2f();
                 }
 
                 int vid = smesh.AppendVertex(vInfo);
@@ -610,7 +608,7 @@ namespace f3
             DMesh3 dmesh = new DMesh3(bNormals, bColors, bUVs, false);
 
             for ( int i = 0; i < mesh.vertexCount; ++i ) {
-                Vector3d v = vertices[i];
+                Vector3d v = vertices[i].ToVector3f();
                 if (bSwapLeftRight) {
                     v.x = -v.x;
                     v.z = -v.z;
@@ -618,7 +616,7 @@ namespace f3
                 NewVertexInfo vInfo = new NewVertexInfo(v);
                 if ( bNormals ) {
                     vInfo.bHaveN = true;
-                    vInfo.n = normals[i];
+                    vInfo.n = normals[i].ToVector3f();
                     if (bSwapLeftRight) {
                         vInfo.n.x = -vInfo.n.x;
                         vInfo.n.z = -vInfo.n.z;

--- a/util/g3ToUnityConvert.cs
+++ b/util/g3ToUnityConvert.cs
@@ -1,4 +1,6 @@
-﻿using g3;
+﻿using FluentAssertions.Common;
+using g3;
+using MathNet.Numerics.Distributions;
 using UnityEngine;
 
 namespace f3
@@ -8,6 +10,8 @@ namespace f3
         public static Vector3f ToVector3f(this Vector3 v) => new Vector3f(v.x, v.y, v.z);
 
         public static Vector3 ToVector3(this Vector3f v) => new Vector3(v.x, v.y, v.z);
+
+        public static Vector3 ToVector3(this Vector3d v) => new Vector3((float)v.x, (float)v.y, (float)v.z);
 
         public static Color ToColor(this Vector3f v) => new Color(v.x, v.y, v.z, 1.0f);
 
@@ -27,6 +31,10 @@ namespace f3
 
         public static Vector2 ToVector2(this Vector2f v) => new Vector2(v.x, v.y);
 
+        public static Vector4f ToVector4f(this Vector4 v) => new Vector4f(v.x, v.y, v.z, v.w);
+
+        public static Vector4 ToVector4(this Vector4f v) => new Vector4(v.x, v.y, v.z, v.w);
+
         public static Quaternionf ToQuaternionf(this Quaternion q) => new Quaternionf(q.x, q.y, q.z, q.w);
 
         public static Quaternion ToQuaternion(this Quaternionf q) => new Quaternion(q.x, q.y, q.z, q.w);
@@ -34,5 +42,22 @@ namespace f3
         public static Ray3f ToRay3f(this Ray r) => new Ray3f(r.origin.ToVector3f(), r.direction.ToVector3f());
 
         public static Ray ToRay(this Ray3f r) => new Ray(r.Origin.ToVector3(), r.Direction.ToVector3());
+
+        public static AxisAlignedBox2f ToAxisAlignedBox2f(this Rect rect) => new AxisAlignedBox2f(rect.min.ToVector2f(), rect.max.ToVector2f());
+        public static Rect ToRect(this AxisAlignedBox2f axisAlignedBox)
+        {
+            Rect ub = new Rect();
+            ub.min = axisAlignedBox.Min.ToVector2();
+            ub.max = axisAlignedBox.Max.ToVector2();
+            return ub;
+        }
+
+        public static AxisAlignedBox3f ToAxisAlignedBox3f(this Bounds bounds) => new AxisAlignedBox3f(bounds.min.ToVector3f(), bounds.max.ToVector3f());
+        public static Bounds ToBounds(this AxisAlignedBox3f axisAlignedBox)
+        {
+            Bounds ub = new Bounds();
+            ub.SetMinMax(axisAlignedBox.Min.ToVector3(), axisAlignedBox.Max.ToVector3());
+            return ub;
+        }
     }
 }

--- a/util/g3ToUnityConvert.cs
+++ b/util/g3ToUnityConvert.cs
@@ -1,0 +1,38 @@
+﻿using g3;
+using UnityEngine;
+
+namespace f3
+{
+    public static class g3ToUnityConvert
+    {
+        public static Vector3f ToVector3f(this Vector3 v) => new Vector3f(v.x, v.y, v.z);
+
+        public static Vector3 ToVector3(this Vector3f v) => new Vector3(v.x, v.y, v.z);
+
+        public static Color ToColor(this Vector3f v) => new Color(v.x, v.y, v.z, 1.0f);
+
+        public static Vector3f ToVector3f(this Color c) => new Vector3f(c.r, c.g, c.b);
+
+        public static Colorf ToColorf(this Color c) => new Colorf(c.r, c.g, c.b, c.a);
+
+        public static Color ToColor(this Colorf c) => new Color(c.r, c.g, c.b, c.a);
+
+        public static Color32 ToColor32(this Colorf c)
+        {
+            Colorb cb = c.ToBytes();
+            return new Color32(cb.r, cb.g, cb.b, cb.a);
+        }
+
+        public static Vector2f ToVector2f(this Vector2 v) => new Vector2f(v.x, v.y);
+
+        public static Vector2 ToVector2(this Vector2f v) => new Vector2(v.x, v.y);
+
+        public static Quaternionf ToQuaternionf(this Quaternion q) => new Quaternionf(q.x, q.y, q.z, q.w);
+
+        public static Quaternion ToQuaternion(this Quaternionf q) => new Quaternion(q.x, q.y, q.z, q.w);
+
+        public static Ray3f ToRay3f(this Ray r) => new Ray3f(r.origin.ToVector3f(), r.direction.ToVector3f());
+
+        public static Ray ToRay(this Ray3f r) => new Ray(r.Origin.ToVector3(), r.Direction.ToVector3());
+    }
+}

--- a/view/CameraManipulator.cs
+++ b/view/CameraManipulator.cs
@@ -76,10 +76,10 @@ namespace f3
 
         public void SceneTumbleAround(FScene scene, Vector3f position, float dx, float dy)
         {
-            Vector3 targetPos = Camera.GetTarget();
+            Vector3 targetPos = Camera.GetTarget().ToVector3();
             Camera.SetTarget(position);
             SceneTumble(scene, Camera, dx, dy);
-            Camera.SetTarget(targetPos);
+            Camera.SetTarget(targetPos.ToVector3f());
         }
 
 
@@ -282,7 +282,7 @@ namespace f3
                 // figure out the pan that we would apply to camera, then apply the delta to the scene
                 Vector3f camPosW = camera.GetPosition();
                 Vector3f camForward = camera.Forward();
-                float fDist = Vector3.Dot((focusPointW - camPosW), camForward);
+                float fDist = Vector3f.Dot((focusPointW - camPosW), camForward);
                 Vector3f newCamPosW = focusPointW - fDist * camForward;
                 Vector3f delta = camPosW - newCamPosW;
 
@@ -306,7 +306,7 @@ namespace f3
             // figure out the pan that we would apply to camera, then apply the delta to the scene
             Vector3f camPosW = camera.GetPosition();
             Vector3f camForward = camera.Forward();
-            float fDist = Vector3.Dot((focusPointW - camPosW), camForward);
+            float fDist = Vector3f.Dot((focusPointW - camPosW), camForward);
             if (fDist == 0)
                 fDist = 2.0f * ((Camera)camera).nearClipPlane;
             Vector3f newCamPosW = focusPointW - fDist * camForward;
@@ -399,9 +399,9 @@ namespace f3
             Vector3f forward = camFrame.Z;
             Vector3f up = camFrame.Y;
             if (rc.StayLevel) {
-                forward = new Vector3(forward.x, 0.0f, forward.z);
+                forward = new Vector3f(forward.x, 0.0f, forward.z);
                 forward.Normalize();
-                up = Vector3.up;
+                up = Vector3f.AxisY;
             }
             Vector3f curScenePos = scene.RootGameObject.GetPosition();
             Vector3f newScenePos = curScenePos - dt * rc.curSpeedY * forward;
@@ -429,11 +429,11 @@ namespace f3
             Vector3f forward = camFrame.Z;
             Vector3f up = camFrame.Y;
             if (rc.StayLevel) {
-                forward = new Vector3(forward.x, 0.0f, forward.z);
+                forward = new Vector3f(forward.x, 0.0f, forward.z);
                 forward.Normalize();
-                up = Vector3.up;
+                up = Vector3f.AxisY;
             }
-            Vector3f right = Vector3.Cross(up, forward);
+            Vector3f right = Vector3f.Cross(up, forward);
             Vector3f curScenePos = scene.RootGameObject.GetPosition();
             Vector3f newScenePos = curScenePos - dt * (rc.curSpeedY * forward + rc.curSpeedX * right);
             scene.RootGameObject.SetPosition(newScenePos);
@@ -458,11 +458,11 @@ namespace f3
             Vector3f forward = camFrame.Z;
             Vector3f up = camFrame.Y;
             if (rc.StayLevel) {
-                forward = new Vector3(forward.x, 0.0f, forward.z);
+                forward = new Vector3f(forward.x, 0.0f, forward.z);
                 forward.Normalize();
-                up = Vector3.up;
+                up = Vector3f.AxisY;
             }
-            Vector3f right = Vector3.Cross(up, forward);
+            Vector3f right = Vector3f.Cross(up, forward);
             Vector3f curScenePos = scene.RootGameObject.GetPosition();
             Vector3f newScenePos = curScenePos - dt * (rc.curSpeedY * up + rc.curSpeedX * right);
             scene.RootGameObject.SetPosition(newScenePos);

--- a/view/CameraTracking.cs
+++ b/view/CameraTracking.cs
@@ -24,12 +24,12 @@ namespace f3 {
 
         public static Vector3f GetPosition(this UnityEngine.Camera c)
         {
-            return c.gameObject.transform.position;
+            return c.gameObject.transform.position.ToVector3f();
         }
 
         public static Quaternionf GetOrientation(this UnityEngine.Camera c)
         {
-            return c.gameObject.transform.rotation;
+            return c.gameObject.transform.rotation.ToQuaternionf();
         }
     }
 
@@ -54,8 +54,8 @@ namespace f3 {
             ShowTarget = false;
 
             targetGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            visibleMaterial = MaterialUtil.CreateTransparentMaterial(Color.red, 0.8f);
-            hiddenMaterial = MaterialUtil.CreateTransparentMaterial(Color.red, 0.4f);
+            visibleMaterial = MaterialUtil.CreateTransparentMaterial(Colorf.Red, 0.8f);
+            hiddenMaterial = MaterialUtil.CreateTransparentMaterial(Colorf.Red, 0.4f);
             targetGO.GetComponent<MeshRenderer>().material = hiddenMaterial;
             targetGO.SetLayer(FPlatform.WidgetOverlayLayer);
             MaterialUtil.DisableShadows(targetGO);
@@ -64,9 +64,9 @@ namespace f3 {
 
         public void Update()
         {
-            targetGO.transform.position = TargetPoint;
-            float fScaling = VRUtil.GetVRRadiusForVisualAngle(TargetPoint, gameObject.transform.position, SceneGraphConfig.CameraPivotVisualDegrees);
-            targetGO.transform.localScale = fScaling * Vector3f.One; 
+            targetGO.transform.position = TargetPoint.ToVector3();
+            float fScaling = VRUtil.GetVRRadiusForVisualAngle(TargetPoint, gameObject.transform.position.ToVector3f(), SceneGraphConfig.CameraPivotVisualDegrees);
+            targetGO.transform.localScale = fScaling * Vector3.one;
 
             if ( ShowTarget && SceneGraphConfig.EnableVisibleCameraPivot ) {
                 Material setMaterial = hiddenMaterial;
@@ -153,8 +153,8 @@ namespace f3 {
 
             List<Camera> newCameras = new List<Camera>();
 
-            Vector3f mainPos = mainCamera.GetPosition();
-            Quaternionf mainRot = mainCamera.GetRotation();
+            Vector3 mainPos = mainCamera.GetPosition().ToVector3();
+            Quaternion mainRot = mainCamera.GetRotation().ToQuaternion();
 
             // create camera for 3D widgets layer
             widgetCamera = new fCamera( Camera.Instantiate((Camera)mainCamera, mainPos, mainRot) );

--- a/view/StandardCameraInteractions.cs
+++ b/view/StandardCameraInteractions.cs
@@ -223,12 +223,12 @@ namespace f3
             if (bInAction == false) {
                 if (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1) || Input.GetMouseButtonDown(2)) {
                     curPos2D = new Vector2(0, 0);
-                    rcInfo = new CameraManipulator.RateControlInfo(curPos2D);
+                    rcInfo = new CameraManipulator.RateControlInfo(curPos2D.ToVector2f());
                     bInAction = bUsingMouse = true;
                 } else if (InputExtension.Get.GamepadRightShoulder.Down || InputExtension.Get.GamepadLeftShoulder.Down) {
                     curPos2D = secondPos2D = new Vector2(0, 0);
-                    rcInfo = new CameraManipulator.RateControlInfo(curPos2D);
-                    rcInfo2 = new CameraManipulator.RateControlInfo(secondPos2D);
+                    rcInfo = new CameraManipulator.RateControlInfo(curPos2D.ToVector2f());
+                    rcInfo2 = new CameraManipulator.RateControlInfo(secondPos2D.ToVector2f());
                     bInAction = bUsingGamepad = true;
                 }
             }
@@ -239,11 +239,11 @@ namespace f3
                 curPos2D.y += mouseDelta.y;
 
                 if (Input.GetMouseButton(0)) {
-                    mainCamera.Manipulator().SceneRateControlledFly(scene, mainCamera, curPos2D, rcInfo);
+                    mainCamera.Manipulator().SceneRateControlledFly(scene, mainCamera, curPos2D.ToVector2f(), rcInfo);
                 } else if (Input.GetMouseButton(1)) {
-                    mainCamera.Manipulator().SceneRateControlledZoom(scene, mainCamera, curPos2D, rcInfo);
+                    mainCamera.Manipulator().SceneRateControlledZoom(scene, mainCamera, curPos2D.ToVector2f(), rcInfo);
                 } else if (Input.GetMouseButton(2)) {
-                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, curPos2D, rcInfo);
+                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, curPos2D.ToVector2f(), rcInfo);
                 }
             }
 
@@ -270,12 +270,12 @@ namespace f3
                 secondPos2D.y = Mathf.Lerp(secondPos2D.y, 0, use_t * Time.deltaTime);
 
                 if (InputExtension.Get.GamepadRightShoulder.Down) {
-                    mainCamera.Manipulator().SceneRateControlledZoom(scene, mainCamera, curPos2D, rcInfo);
+                    mainCamera.Manipulator().SceneRateControlledZoom(scene, mainCamera, curPos2D.ToVector2f(), rcInfo);
                     secondPos2D[0] = 0;
-                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, secondPos2D, rcInfo2);
+                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, secondPos2D.ToVector2f(), rcInfo2);
                 } else if (InputExtension.Get.GamepadLeftShoulder.Down) {
-                    mainCamera.Manipulator().SceneRateControlledFly(scene, mainCamera, curPos2D, rcInfo);
-                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, secondPos2D, rcInfo2);
+                    mainCamera.Manipulator().SceneRateControlledFly(scene, mainCamera, curPos2D.ToVector2f(), rcInfo);
+                    mainCamera.Manipulator().SceneRateControlledEgogentricPan(scene, mainCamera, secondPos2D.ToVector2f(), rcInfo2);
                 }
 
             }

--- a/widgets/AxisRotationWidget.cs
+++ b/widgets/AxisRotationWidget.cs
@@ -71,8 +71,8 @@ namespace f3
 			Vector3f dv = planeHitW - rotateFrameW.Origin;
 			int iX = (nRotationAxis + 1) % 3;
 			int iY = (nRotationAxis + 2) % 3;
-			float fX = Vector3.Dot( dv, rotateFrameW.GetAxis(iX) );
-			float fY = Vector3.Dot( dv, rotateFrameW.GetAxis(iY) );
+			float fX = Vector3f.Dot( dv, rotateFrameW.GetAxis(iX) );
+			float fY = Vector3f.Dot( dv, rotateFrameW.GetAxis(iY) );
 
 			float fNewAngle = (float)Math.Atan2 (fY, fX);
             if (AbsoluteAngleConstraintF != null)
@@ -95,7 +95,7 @@ namespace f3
 
             // construct new frame for target that is rotated around axis
             Vector3f rotateAxisL = rotateFrameL.GetAxis(nRotationAxis);
-			Quaternionf q = Quaternion.AngleAxis(fDeltaAngle * Mathf.Rad2Deg, rotateAxisL );
+			Quaternionf q = Quaternion.AngleAxis(fDeltaAngle * Mathf.Rad2Deg, rotateAxisL.ToVector3() ).ToQuaternionf();
 			Frame3f newFrame = rotateFrameL;
 			newFrame.Rotation = q * newFrame.Rotation;		// order matters here!
 

--- a/widgets/AxisTrackballRotationWidget.cs
+++ b/widgets/AxisTrackballRotationWidget.cs
@@ -50,8 +50,8 @@ namespace f3
             var radiusVectorOld = startIntersectionPointW - originW;
             var radiusVector = intersectionPointW - originW;
             
-            Debug.DrawLine(originW, startIntersectionPointW, Colorf.Blue);
-            Debug.DrawLine(originW, intersectionPointW, Colorf.Red);
+            Debug.DrawLine(originW.ToVector3(), startIntersectionPointW.ToVector3(), UnityEngine.Color.blue);
+            Debug.DrawLine(originW.ToVector3(), intersectionPointW.ToVector3(), UnityEngine.Color.red);
 
             if (rotateSpeed == 1)
                 return Quaternionf.FromToConstrained(radiusVectorOld, radiusVector, aroundW);

--- a/widgets/AxisTransformGizmo.cs
+++ b/widgets/AxisTransformGizmo.cs
@@ -608,7 +608,7 @@ namespace f3
 		{
 			hit = null;
 			GameObjectRayHit hitg = null;
-			if (is_interactive && FindGORayIntersection(ray, out hitg)) {
+			if (is_interactive && FindGORayIntersection(ray.ToRay(), out hitg)) {
 				if (hitg.hitGO != null) {
 					hit = new UIRayHit (hitg, this);
 					return true;

--- a/widgets/BaseTransformGizmo.cs
+++ b/widgets/BaseTransformGizmo.cs
@@ -162,7 +162,7 @@ namespace f3
         {
             hit = null;
             GameObjectRayHit hitg = null;
-            if (is_interactive && FindGORayIntersection(ray, out hitg)) {
+            if (is_interactive && FindGORayIntersection(ray.ToRay(), out hitg)) {
                 if (hitg.hitGO != null) {
                     hit = new UIRayHit(hitg, this);
                     return true;

--- a/widgets/TransformWrappers.cs
+++ b/widgets/TransformWrappers.cs
@@ -54,7 +54,7 @@ namespace f3
                 foreach (SceneObject so in curChange.childSOs)
                 {
                     curChange.before.Add(so.GetLocalFrame(CoordSpace.SceneCoords));
-                    curChange.scaleBefore.Add(UnityUtil.GetFreeLocalScale(so.RootGameObject));
+                    curChange.scaleBefore.Add(UnityUtil.GetFreeLocalScale(so.RootGameObject).ToVector3f());
                 }
             }
         }
@@ -76,7 +76,7 @@ namespace f3
                 foreach (SceneObject so in curChange.childSOs)
                 {
                     curChange.after.Add(so.GetLocalFrame(CoordSpace.SceneCoords));
-                    curChange.scaleAfter.Add(UnityUtil.GetFreeLocalScale(so.RootGameObject));
+                    curChange.scaleAfter.Add(UnityUtil.GetFreeLocalScale(so.RootGameObject).ToVector3f());
                 }
             }
 

--- a/widgets/UniformScaleWidget.cs
+++ b/widgets/UniformScaleWidget.cs
@@ -38,7 +38,7 @@ namespace f3
 
             // save local and world frames
             scaleFrameW = target.GetLocalFrame(CoordSpace.WorldCoords);
-            cameraFrameW = new Frame3f(scaleFrameW.Origin, activeCamera.transform.rotation);
+            cameraFrameW = new Frame3f(scaleFrameW.Origin, activeCamera.transform.rotation.ToQuaternionf());
             startScale = target.GetLocalScale();
 
             // save initial hitpos in plane


### PR DESCRIPTION
## Problem

The `G3_UNITY_UNITY` symbol that is used for conditionally including implicit conversions for `g3` types makes us use `geomerty3sharp` as a submodule to Unity3d

Sadly, this hierarchy of Assets imports all files in the submodule into the Unity solution. It means that we can add neither benchmarks nor tests to the `g3` repo

## Solution

Get rid of implicit conversions between `g3` and unity, make explicit calls to converting functions in `frame3sharp`

**Note**: I haven't changed the logic at all. Even some obvious performance considerations aren't taken into account the goal is to keep everything exactly as it used to be

In this solution, I'm only removing the implicit casts in `f3`, moving every using converter from g3 to f3

## The next

In the second part, I'm going to cover the conversion logic required for our Vision application